### PR TITLE
Support drag preview/image with drag&drop and off-screen rendering (Issue 1715).

### DIFF
--- a/include/capi/cef_drag_data_capi.h
+++ b/include/capi/cef_drag_data_capi.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include "include/capi/cef_base_capi.h"
+#include "include/capi/cef_image_capi.h"
 #include "include/capi/cef_stream_capi.h"
 
 #ifdef __cplusplus
@@ -195,6 +196,21 @@ typedef struct _cef_drag_data_t {
   ///
   void (CEF_CALLBACK *add_file)(struct _cef_drag_data_t* self,
       const cef_string_t* path, const cef_string_t* display_name);
+
+  ///
+  // Get image representation of drag data (may be NULL).
+  ///
+  struct _cef_image_t* (CEF_CALLBACK *get_image)(struct _cef_drag_data_t* self);
+
+  ///
+  // Get image hotspot (drag start location relative to image dimensions).
+  ///
+  cef_point_t (CEF_CALLBACK *get_image_hotspot)(struct _cef_drag_data_t* self);
+
+  ///
+  // Whether image representation of drag data is available.
+  ///
+  int (CEF_CALLBACK *has_image)(struct _cef_drag_data_t* self);
 } cef_drag_data_t;
 
 

--- a/include/cef_drag_data.h
+++ b/include/cef_drag_data.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include "include/cef_base.h"
+#include "include/cef_image.h"
 #include "include/cef_stream.h"
 #include <vector>
 
@@ -193,6 +194,24 @@ class CefDragData : public virtual CefBaseRefCounted {
   ///
   /*--cef(optional_param=display_name)--*/
   virtual void AddFile(const CefString& path, const CefString& display_name) =0;
+
+  ///
+  // Get image representation of drag data (may be NULL).
+  ///
+  /*--cef()--*/
+  virtual CefRefPtr<CefImage> GetImage() =0;
+
+  ///
+  // Get image hotspot (drag start location relative to image dimensions).
+  ///
+  /*--cef()--*/
+  virtual CefPoint GetImageHotspot() =0;
+
+  ///
+  // Whether image representation of drag data is available.
+  ///
+  /*--cef()--*/
+  virtual bool HasImage() =0;
 };
 
 #endif  // CEF_INCLUDE_CEF_DRAG_DATA_H_

--- a/libcef/browser/osr/browser_platform_delegate_osr.cc
+++ b/libcef/browser/osr/browser_platform_delegate_osr.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "libcef/browser/browser_host_impl.h"
+#include "libcef/browser/image_impl.h"
 #include "libcef/browser/osr/render_widget_host_view_osr.h"
 #include "libcef/browser/osr/web_contents_view_osr.h"
 #include "libcef/common/drag_data_impl.h"
@@ -432,7 +433,11 @@ void CefBrowserPlatformDelegateOsr::StartDragging(
   CefRefPtr<CefRenderHandler> handler =
       browser_->GetClient()->GetRenderHandler();
   if (handler.get()) {
-    CefRefPtr<CefDragDataImpl> drag_data(new CefDragDataImpl(drop_data));
+    CefRefPtr<CefImage> cef_image(new CefImageImpl(image));
+    CefPoint cef_image_pos(CefPoint(image_offset.x(), image_offset.y()));
+    CefRefPtr<CefDragDataImpl> drag_data(new CefDragDataImpl(drop_data,
+                                                             cef_image,
+                                                             cef_image_pos));
     drag_data->SetReadOnly(true);
     base::MessageLoop::ScopedNestableTaskAllower allow(
         base::MessageLoop::current());

--- a/libcef/common/drag_data_impl.cc
+++ b/libcef/common/drag_data_impl.cc
@@ -19,6 +19,15 @@ CefDragDataImpl::CefDragDataImpl(const content::DropData& data)
       read_only_(false) {
 }
 
+CefDragDataImpl::CefDragDataImpl(const content::DropData& data,
+                                 CefRefPtr<CefImage> image,
+                                 const CefPoint& image_hotspot)
+    : data_(data),
+      image_(image),
+      image_hotspot_(image_hotspot),
+      read_only_(false) {
+}
+
 CefDragDataImpl::CefDragDataImpl()
     : read_only_(false) {
 }
@@ -31,7 +40,7 @@ CefRefPtr<CefDragData> CefDragDataImpl::Clone() {
   CefDragDataImpl* drag_data = NULL;
   {
     base::AutoLock lock_scope(lock_);
-    drag_data = new CefDragDataImpl(data_);
+    drag_data = new CefDragDataImpl(data_, image_, image_hotspot_);
   }
   return drag_data;
 }
@@ -186,4 +195,32 @@ void CefDragDataImpl::SetReadOnly(bool read_only) {
     return;
 
   read_only_ = read_only;
+}
+
+void CefDragDataImpl::SetImage(CefRefPtr<CefImage> image) {
+  base::AutoLock lock_scope(lock_);
+  CHECK_READONLY_RETURN_VOID();
+  image_ = image;
+}
+
+void CefDragDataImpl::SetImageHotspot(const CefPoint& point) {
+  base::AutoLock lock_scope(lock_);
+  CHECK_READONLY_RETURN_VOID();
+  image_hotspot_.Set(point.x, point.y);
+}
+
+CefRefPtr<CefImage> CefDragDataImpl::GetImage() {
+  base::AutoLock lock_scope(lock_);
+  return image_;
+}
+
+CefPoint CefDragDataImpl::GetImageHotspot() {
+  base::AutoLock lock_scope(lock_);
+  return image_hotspot_;
+}
+
+bool CefDragDataImpl::HasImage() {
+  base::AutoLock lock_scope(lock_);
+  if (image_) return true;
+  else return false;
 }

--- a/libcef/common/drag_data_impl.cc
+++ b/libcef/common/drag_data_impl.cc
@@ -197,18 +197,6 @@ void CefDragDataImpl::SetReadOnly(bool read_only) {
   read_only_ = read_only;
 }
 
-void CefDragDataImpl::SetImage(CefRefPtr<CefImage> image) {
-  base::AutoLock lock_scope(lock_);
-  CHECK_READONLY_RETURN_VOID();
-  image_ = image;
-}
-
-void CefDragDataImpl::SetImageHotspot(const CefPoint& point) {
-  base::AutoLock lock_scope(lock_);
-  CHECK_READONLY_RETURN_VOID();
-  image_hotspot_.Set(point.x, point.y);
-}
-
 CefRefPtr<CefImage> CefDragDataImpl::GetImage() {
   base::AutoLock lock_scope(lock_);
   return image_;
@@ -221,6 +209,5 @@ CefPoint CefDragDataImpl::GetImageHotspot() {
 
 bool CefDragDataImpl::HasImage() {
   base::AutoLock lock_scope(lock_);
-  if (image_) return true;
-  else return false;
+  return image_ ? true : false;
 }

--- a/libcef/common/drag_data_impl.h
+++ b/libcef/common/drag_data_impl.h
@@ -19,9 +19,9 @@ class CefDragDataImpl : public CefDragData {
  public:
   CefDragDataImpl();
   explicit CefDragDataImpl(const content::DropData& data);
-  explicit CefDragDataImpl(const content::DropData& data,
-                           CefRefPtr<CefImage> image,
-                           const CefPoint& image_hotspot);
+  CefDragDataImpl(const content::DropData& data,
+                  CefRefPtr<CefImage> image,
+                  const CefPoint& image_hotspot);
 
   CefRefPtr<CefDragData> Clone() override;
   bool IsReadOnly() override;
@@ -55,9 +55,6 @@ class CefDragDataImpl : public CefDragData {
   }
 
   void SetReadOnly(bool read_only);
-
-  void SetImage(CefRefPtr<CefImage> image);
-  void SetImageHotspot(const CefPoint& point);
 
   base::Lock& lock() { return lock_; }
 

--- a/libcef/common/drag_data_impl.h
+++ b/libcef/common/drag_data_impl.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "include/cef_drag_data.h"
+#include "include/cef_image.h"
 
 #include <vector>
 
@@ -18,6 +19,9 @@ class CefDragDataImpl : public CefDragData {
  public:
   CefDragDataImpl();
   explicit CefDragDataImpl(const content::DropData& data);
+  explicit CefDragDataImpl(const content::DropData& data,
+                           CefRefPtr<CefImage> image,
+                           const CefPoint& image_hotspot);
 
   CefRefPtr<CefDragData> Clone() override;
   bool IsReadOnly() override;
@@ -41,6 +45,9 @@ class CefDragDataImpl : public CefDragData {
   void SetFragmentBaseURL(const CefString& fragment) override;
   void ResetFileContents() override;
   void AddFile(const CefString& path, const CefString& display_name) override;
+  CefRefPtr<CefImage> GetImage() override;
+  CefPoint GetImageHotspot() override;
+  bool HasImage() override;
 
   // This method is not safe. Use Lock/Unlock to get mutually exclusive access.
   content::DropData* drop_data() {
@@ -49,10 +56,15 @@ class CefDragDataImpl : public CefDragData {
 
   void SetReadOnly(bool read_only);
 
+  void SetImage(CefRefPtr<CefImage> image);
+  void SetImageHotspot(const CefPoint& point);
+
   base::Lock& lock() { return lock_; }
 
  private:
   content::DropData data_;
+  CefRefPtr<CefImage> image_;
+  CefPoint image_hotspot_;
 
   // True if this object is read-only.
   bool read_only_;

--- a/libcef_dll/cpptoc/drag_data_cpptoc.cc
+++ b/libcef_dll/cpptoc/drag_data_cpptoc.cc
@@ -11,6 +11,7 @@
 //
 
 #include "libcef_dll/cpptoc/drag_data_cpptoc.h"
+#include "libcef_dll/cpptoc/image_cpptoc.h"
 #include "libcef_dll/cpptoc/stream_writer_cpptoc.h"
 #include "libcef_dll/transfer_util.h"
 
@@ -367,6 +368,50 @@ void CEF_CALLBACK drag_data_add_file(struct _cef_drag_data_t* self,
       CefString(display_name));
 }
 
+struct _cef_image_t* CEF_CALLBACK drag_data_get_image(
+    struct _cef_drag_data_t* self) {
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  DCHECK(self);
+  if (!self)
+    return NULL;
+
+  // Execute
+  CefRefPtr<CefImage> _retval = CefDragDataCppToC::Get(self)->GetImage();
+
+  // Return type: refptr_same
+  return CefImageCppToC::Wrap(_retval);
+}
+
+cef_point_t CEF_CALLBACK drag_data_get_image_hotspot(
+    struct _cef_drag_data_t* self) {
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  DCHECK(self);
+  if (!self)
+    return CefPoint();
+
+  // Execute
+  cef_point_t _retval = CefDragDataCppToC::Get(self)->GetImageHotspot();
+
+  // Return type: simple
+  return _retval;
+}
+
+int CEF_CALLBACK drag_data_has_image(struct _cef_drag_data_t* self) {
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  DCHECK(self);
+  if (!self)
+    return 0;
+
+  // Execute
+  bool _retval = CefDragDataCppToC::Get(self)->HasImage();
+
+  // Return type: bool
+  return _retval;
+}
+
 }  // namespace
 
 
@@ -395,6 +440,9 @@ CefDragDataCppToC::CefDragDataCppToC() {
   GetStruct()->set_fragment_base_url = drag_data_set_fragment_base_url;
   GetStruct()->reset_file_contents = drag_data_reset_file_contents;
   GetStruct()->add_file = drag_data_add_file;
+  GetStruct()->get_image = drag_data_get_image;
+  GetStruct()->get_image_hotspot = drag_data_get_image_hotspot;
+  GetStruct()->has_image = drag_data_has_image;
 }
 
 template<> CefRefPtr<CefDragData> CefCppToCRefCounted<CefDragDataCppToC,

--- a/libcef_dll/ctocpp/drag_data_ctocpp.cc
+++ b/libcef_dll/ctocpp/drag_data_ctocpp.cc
@@ -11,6 +11,7 @@
 //
 
 #include "libcef_dll/ctocpp/drag_data_ctocpp.h"
+#include "libcef_dll/ctocpp/image_ctocpp.h"
 #include "libcef_dll/ctocpp/stream_writer_ctocpp.h"
 #include "libcef_dll/transfer_util.h"
 
@@ -370,6 +371,48 @@ void CefDragDataCToCpp::AddFile(const CefString& path,
   _struct->add_file(_struct,
       path.GetStruct(),
       display_name.GetStruct());
+}
+
+CefRefPtr<CefImage> CefDragDataCToCpp::GetImage() {
+  cef_drag_data_t* _struct = GetStruct();
+  if (CEF_MEMBER_MISSING(_struct, get_image))
+    return NULL;
+
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  // Execute
+  cef_image_t* _retval = _struct->get_image(_struct);
+
+  // Return type: refptr_same
+  return CefImageCToCpp::Wrap(_retval);
+}
+
+CefPoint CefDragDataCToCpp::GetImageHotspot() {
+  cef_drag_data_t* _struct = GetStruct();
+  if (CEF_MEMBER_MISSING(_struct, get_image_hotspot))
+    return CefPoint();
+
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  // Execute
+  cef_point_t _retval = _struct->get_image_hotspot(_struct);
+
+  // Return type: simple
+  return _retval;
+}
+
+bool CefDragDataCToCpp::HasImage() {
+  cef_drag_data_t* _struct = GetStruct();
+  if (CEF_MEMBER_MISSING(_struct, has_image))
+    return false;
+
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  // Execute
+  int _retval = _struct->has_image(_struct);
+
+  // Return type: bool
+  return _retval?true:false;
 }
 
 

--- a/libcef_dll/ctocpp/drag_data_ctocpp.h
+++ b/libcef_dll/ctocpp/drag_data_ctocpp.h
@@ -54,6 +54,9 @@ class CefDragDataCToCpp
   void SetFragmentBaseURL(const CefString& base_url) OVERRIDE;
   void ResetFileContents() OVERRIDE;
   void AddFile(const CefString& path, const CefString& display_name) OVERRIDE;
+  CefRefPtr<CefImage> GetImage() OVERRIDE;
+  CefPoint GetImageHotspot() OVERRIDE;
+  bool HasImage() OVERRIDE;
 };
 
 #endif  // CEF_LIBCEF_DLL_CTOCPP_DRAG_DATA_CTOCPP_H_

--- a/tests/ceftests/os_rendering_unittest.cc
+++ b/tests/ceftests/os_rendering_unittest.cc
@@ -1007,6 +1007,28 @@ class OSRTestHandler : public RoutingTestHandler,
                      CefRenderHandler::DragOperationsMask allowed_ops,
                      int x, int y) override {
     if (test_type_ == OSR_TEST_DRAG_DROP_START_DRAGGING && started()) {
+      // Drag image representation
+      EXPECT_TRUE(drag_data->HasImage());
+      CefRefPtr<CefImage> image = drag_data->GetImage();
+      EXPECT_TRUE(image.get() != NULL);
+      if (image.get()) {
+        // Drag image height seem to be always + 1px greater than
+        // the drag rect on Linux. But whether this is true on all
+        // platforms not sure, so to be safe lets allow it to be
+        // +/- 1px.
+        EXPECT_GE(image->GetWidth(), GetScaledInt(kDragDivRect.width));
+        EXPECT_LE(image->GetWidth(), GetScaledInt(kDragDivRect.width) + 1);
+        EXPECT_GE(image->GetHeight(), GetScaledInt(kDragDivRect.height));
+        EXPECT_LE(image->GetHeight(), GetScaledInt(kDragDivRect.height) + 1);
+      }
+      // During testing hotspot was (15, 23) and with scale_factor 2x
+      // it was (15, 18). I don't know how the algorithm works, so
+      // testing only rect boundaries.
+      CefPoint hotspot = drag_data->GetImageHotspot();
+      EXPECT_GT(hotspot.x, 0);
+      EXPECT_LT(hotspot.x, GetScaledInt(kDragDivRect.width));
+      EXPECT_GT(hotspot.y, 0);
+      EXPECT_LT(hotspot.y, GetScaledInt(kDragDivRect.height));
       DestroySucceededTestSoon();
       return false;
     } else if ((test_type_ == OSR_TEST_DRAG_DROP_UPDATE_CURSOR ||


### PR DESCRIPTION
Bitbucket issue: https://bitbucket.org/chromiumembedded/cef/issues/1715/support-drag-preview-image-with-drag-drop

This code was already reviewed, except for the added unit test. This is a second pull request. Initial pull request was on bitbucket:
https://bitbucket.org/chromiumembedded/cef/pull-requests/80/add-functions-to-support-image/diff

Command to run test for the new functionality:
> ./ceftests --gtest_filter=OSRTest.DragDropStartDragging*

Tested on Linux.
CEF branch 3029.