### PR TITLE
Fix CefRawPtr errors when building libcef_dll_wrapper with VS2008/VS2010 (Issue 2155)

### DIFF
--- a/include/internal/cef_ptr.h
+++ b/include/internal/cef_ptr.h
@@ -186,10 +186,13 @@ using CefOwnPtr = scoped_ptr<T, D>;
 // A CefRawPtr<T> is the same as T*
 ///
 #if defined(HAS_CPP11_TEMPLATE_ALIAS_SUPPORT)
+#define CEF_RAW_PTR_GET(r) r
 template <class T>
 using CefRawPtr = T*;
 #else
 // Simple wrapper implementation that behaves as much like T* as possible.
+// CEF_RAW_PTR_GET is required for VS2008 compatibility (Issue #2155).
+#define CEF_RAW_PTR_GET(r) r.get()
 template <class T>
 class CefRawPtr {
  public:

--- a/libcef_dll/ctocpp/test/translator_test_scoped_client_ctocpp.cc
+++ b/libcef_dll/ctocpp/test/translator_test_scoped_client_ctocpp.cc
@@ -58,7 +58,8 @@ template<> cef_translator_test_scoped_client_t* CefCToCppScoped<CefTranslatorTes
     return reinterpret_cast<cef_translator_test_scoped_client_t*>(
         CefTranslatorTestScopedClientChildCToCpp::UnwrapRaw(
         CefRawPtr<CefTranslatorTestScopedClientChild>(
-        reinterpret_cast<CefTranslatorTestScopedClientChild*>(c))));
+        reinterpret_cast<CefTranslatorTestScopedClientChild*>(CEF_RAW_PTR_GET(
+        c)))));
   }
   NOTREACHED() << "Unexpected class type: " << type;
   return NULL;

--- a/libcef_dll/ctocpp/test/translator_test_scoped_library_child_ctocpp.cc
+++ b/libcef_dll/ctocpp/test/translator_test_scoped_library_child_ctocpp.cc
@@ -117,7 +117,8 @@ template<> cef_translator_test_scoped_library_child_t* CefCToCppScoped<CefTransl
     return reinterpret_cast<cef_translator_test_scoped_library_child_t*>(
         CefTranslatorTestScopedLibraryChildChildCToCpp::UnwrapRaw(
         CefRawPtr<CefTranslatorTestScopedLibraryChildChild>(
-        reinterpret_cast<CefTranslatorTestScopedLibraryChildChild*>(c))));
+        reinterpret_cast<CefTranslatorTestScopedLibraryChildChild*>(
+        CEF_RAW_PTR_GET(c)))));
   }
   NOTREACHED() << "Unexpected class type: " << type;
   return NULL;

--- a/libcef_dll/ctocpp/test/translator_test_scoped_library_ctocpp.cc
+++ b/libcef_dll/ctocpp/test/translator_test_scoped_library_ctocpp.cc
@@ -94,13 +94,15 @@ template<> cef_translator_test_scoped_library_t* CefCToCppScoped<CefTranslatorTe
     return reinterpret_cast<cef_translator_test_scoped_library_t*>(
         CefTranslatorTestScopedLibraryChildCToCpp::UnwrapRaw(
         CefRawPtr<CefTranslatorTestScopedLibraryChild>(
-        reinterpret_cast<CefTranslatorTestScopedLibraryChild*>(c))));
+        reinterpret_cast<CefTranslatorTestScopedLibraryChild*>(CEF_RAW_PTR_GET(
+        c)))));
   }
   if (type == WT_TRANSLATOR_TEST_SCOPED_LIBRARY_CHILD_CHILD) {
     return reinterpret_cast<cef_translator_test_scoped_library_t*>(
         CefTranslatorTestScopedLibraryChildChildCToCpp::UnwrapRaw(
         CefRawPtr<CefTranslatorTestScopedLibraryChildChild>(
-        reinterpret_cast<CefTranslatorTestScopedLibraryChildChild*>(c))));
+        reinterpret_cast<CefTranslatorTestScopedLibraryChildChild*>(
+        CEF_RAW_PTR_GET(c)))));
   }
   NOTREACHED() << "Unexpected class type: " << type;
   return NULL;

--- a/tools/make_ctocpp_impl.py
+++ b/tools/make_ctocpp_impl.py
@@ -550,7 +550,7 @@ def make_ctocpp_unwrap_derived(header, cls, base_scoped):
                        '  }\n'
             impl[1] += '  if (type == '+get_wrapper_type_enum(clsname)+') {\n'+\
                        '    return reinterpret_cast<'+get_capi_name(cls.get_name(), True)+'*>('+\
-                       clsname+'CToCpp::UnwrapRaw(CefRawPtr<'+clsname+'>(reinterpret_cast<'+clsname+'*>(c))));\n'+\
+                       clsname+'CToCpp::UnwrapRaw(CefRawPtr<'+clsname+'>(reinterpret_cast<'+clsname+'*>(CEF_RAW_PTR_GET(c)))));\n'+\
                        '  }\n'
     else:
         impl = ''


### PR DESCRIPTION
This is a second approach for branch 3029 this time. I have made changes as requested in PR #1.

Issue 2155 on bitbucket: https://bitbucket.org/chromiumembedded/cef/issues/2155

Tested with VS2008, VS2010, VS2015.