### PR TITLE
Expose CefOverridePath to allow overriding DIR_EXE/DIR_MODULE paths (Issue 1936)

### DIFF
--- a/include/capi/cef_path_util_capi.h
+++ b/include/capi/cef_path_util_capi.h
@@ -51,6 +51,16 @@ extern "C" {
 ///
 CEF_EXPORT int cef_get_path(cef_path_key_t key, cef_string_t* path);
 
+///
+// Override the path associated with the specified |key|. This cannot be used to
+// change the value of PK_DIR_CURRENT, but that should be obvious. Also, if the
+// path specifies a directory that does not exist, the directory will be created
+// by this function.  This function returns true (1) if successful. WARNING:
+// Consumers of CefGetPath may expect paths to be constant over the lifetime of
+// the app, so this function should be used with caution.
+///
+CEF_EXPORT int cef_override_path(cef_path_key_t key, const cef_string_t* path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/cef_path_util.h
+++ b/include/cef_path_util.h
@@ -49,4 +49,15 @@ typedef cef_path_key_t PathKey;
 /*--cef()--*/
 bool CefGetPath(PathKey key, CefString& path);
 
+///
+// Override the path associated with the specified |key|. This cannot
+// be used to change the value of PK_DIR_CURRENT, but that should be obvious.
+// Also, if the path specifies a directory that does not exist, the directory
+// will be created by this method.  This method returns true if successful.
+// WARNING: Consumers of CefGetPath may expect paths to be constant
+// over the lifetime of the app, so this method should be used with caution.
+///
+/*--cef()--*/
+bool CefOverridePath(PathKey key, const CefString& path);
+
 #endif  // CEF_INCLUDE_CEF_PATH_UTIL_H_

--- a/libcef/browser/path_util_impl.cc
+++ b/libcef/browser/path_util_impl.cc
@@ -51,3 +51,38 @@ bool CefGetPath(PathKey key, CefString& path) {
 
   return false;
 }
+
+bool CefOverridePath(PathKey key, const CefString& path) {
+  int pref_key = base::PATH_START;
+  switch(key) {
+    case PK_DIR_EXE:
+      pref_key = base::DIR_EXE;
+      break;
+    case PK_DIR_MODULE:
+      pref_key = base::DIR_MODULE;
+      break;
+    case PK_DIR_TEMP:
+      pref_key = base::DIR_TEMP;
+      break;
+    case PK_FILE_EXE:
+      pref_key = base::FILE_EXE;
+      break;
+    case PK_FILE_MODULE:
+      pref_key = base::FILE_MODULE;
+      break;
+#if defined(OS_WIN)
+    case PK_LOCAL_APP_DATA:
+      pref_key = base::DIR_LOCAL_APP_DATA;
+      break;
+#endif
+    case PK_USER_DATA:
+      pref_key = chrome::DIR_USER_DATA;
+      break;
+    default:
+      NOTREACHED() << "invalid argument";
+      return false;
+  }
+
+  base::FilePath file_path = base::FilePath(path);
+  return PathService::Override(pref_key, file_path);
+}

--- a/libcef_dll/libcef_dll.cc
+++ b/libcef_dll/libcef_dll.cc
@@ -959,6 +959,23 @@ CEF_EXPORT int cef_get_path(cef_path_key_t key, cef_string_t* path) {
   return _retval;
 }
 
+CEF_EXPORT int cef_override_path(cef_path_key_t key, const cef_string_t* path) {
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  // Verify param: path; type: string_byref_const
+  DCHECK(path);
+  if (!path)
+    return 0;
+
+  // Execute
+  bool _retval = CefOverridePath(
+      key,
+      CefString(path));
+
+  // Return type: bool
+  return _retval;
+}
+
 CEF_EXPORT int cef_launch_process(struct _cef_command_line_t* command_line) {
   // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
 

--- a/libcef_dll/wrapper/libcef_dll_wrapper.cc
+++ b/libcef_dll/wrapper/libcef_dll_wrapper.cc
@@ -880,6 +880,23 @@ CEF_GLOBAL bool CefGetPath(PathKey key, CefString& path) {
   return _retval?true:false;
 }
 
+CEF_GLOBAL bool CefOverridePath(PathKey key, const CefString& path) {
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  // Verify param: path; type: string_byref_const
+  DCHECK(!path.empty());
+  if (path.empty())
+    return false;
+
+  // Execute
+  int _retval = cef_override_path(
+      key,
+      path.GetStruct());
+
+  // Return type: bool
+  return _retval?true:false;
+}
+
 CEF_GLOBAL bool CefLaunchProcess(CefRefPtr<CefCommandLine> command_line) {
   // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
 


### PR DESCRIPTION
This is to fix Issue 1936 "Override paths: DIR_EXE = DIR_MODULE = <libcef.so.path> on Linux":
https://bitbucket.org/chromiumembedded/cef/issues/1936/override-paths-dir_exe-dir_module-on-linux

This is an alternative pull request to PR 66 on bitbucket:
https://bitbucket.org/chromiumembedded/cef/pull-requests/66/override-paths-dir_exe-dir_module-on-linux/diff

Overriding DIR_EXE / DIR_MODULE works fine when done before calling CefInitialize. I have been using this patch for about 6 months with CEF v54..v58 and it works good, this fixed problems described in Issue 1936 in CEF Python project. Similar issues are also having users of java-cef project, they are forced to put binaries in jre/bin.

Code that fixes issue:
```Python
if LINUX:
    CefOverridePath(PK_DIR_EXE, cef_module_dir)
    CefOverridePath(PK_DIR_MODULE, cef_module_dir)
CefInitialize()
```