### PR TITLE
Fix wrong calling convention with gcc compiler on Windows (Issue 1209)

### DIFF
--- a/include/internal/cef_export.h
+++ b/include/internal/cef_export.h
@@ -48,7 +48,11 @@
 #elif defined(COMPILER_GCC)
 
 #define CEF_EXPORT __attribute__ ((visibility("default")))
+#ifdef OS_WIN
+#define CEF_CALLBACK __stdcall
+#else
 #define CEF_CALLBACK
+#endif
 
 #endif  // COMPILER_GCC
 

--- a/include/internal/cef_export.h
+++ b/include/internal/cef_export.h
@@ -48,7 +48,7 @@
 #elif defined(COMPILER_GCC)
 
 #define CEF_EXPORT __attribute__ ((visibility("default")))
-#ifdef OS_WIN
+#if defined(OS_WIN)
 #define CEF_CALLBACK __stdcall
 #else
 #define CEF_CALLBACK


### PR DESCRIPTION
Bitbucket issue:
https://bitbucket.org/chromiumembedded/cef/issues/1209/wrong-calling-convention-for-callbacks