### PR TITLE
CMake - Add additional if folder exists checks for the Minimal Distribution

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -199,10 +199,12 @@ add_subdirectory(${CEF_LIBCEF_DLL_WRAPPER_PATH} libcef_dll_wrapper)
 # Include application targets.
 # Comes from the <target>/CMakeLists.txt file in the current directory.
 # TODO: Change these lines to match your project target when you copy this file.
-add_subdirectory(tests/cefclient)
-add_subdirectory(tests/cefsimple)
-add_subdirectory(tests/gtest)
-add_subdirectory(tests/ceftests)
+if(EXISTS tests)
+  add_subdirectory(tests/cefclient)
+  add_subdirectory(tests/cefsimple)
+  add_subdirectory(tests/gtest)
+  add_subdirectory(tests/ceftests)
+endif()
 
 # Display configuration settings.
 PRINT_CEF_CONFIG()


### PR DESCRIPTION
One possible solution to resolve https://bitbucket.org/chromiumembedded/cef/issues/2169/cmake-error-in-minimal-distribution-builds 

> Include application targets.
> Comes from the <target>/CMakeLists.txt file in the current directory.
> TODO: Change these lines to match your project target when you copy this file.

The comment probably needs some additions, the additional `if exists` check makes the `TODO` a little less clear, thoughts? Happy to make any changes, just let me know.


