### PR TITLE
CefValueType definition error

### DIFF
--- a/include/internal/cef_types.h
+++ b/include/internal/cef_types.h
@@ -1550,8 +1550,8 @@ typedef enum {
 // Supported value types.
 ///
 typedef enum {
-  VTYPE_INVALID = 0,
-  VTYPE_NULL,
+  VTYPE_INVALID = -1,
+  VTYPE_NULL = 0,
   VTYPE_BOOL,
   VTYPE_INT,
   VTYPE_DOUBLE,


### PR DESCRIPTION
typedef enum {
   VTYPE_INVALID = 0,
   VTYPE_NULL,
   VTYPE_BOOL,
   VTYPE_INT,
   VTYPE_DOUBLE,
   VTYPE_STRING,
   VTYPE_BINARY,
   VTYPE_DICTIONARY,
   VTYPE_LIST, //value is 8
} cef_value_type_t;

The definition of base::Value::Type in chromium is
   enum class Type: unsigned char {
     NONE = 0,
     BOOLEAN,
     INTEGER,
     DOUBLE,
     STRING,
     BINARY,
     DICTIONARY,
     LIST, //value is 7
     // TODO(crbug.com/859477): Remove once root cause is found.
     DEAD
     // Note: Do not add more types. See the file-level comment above for why.
   };
So it will crash when calling CefRefPtr<CefListValue> GetList(size_t index)