### PR TITLE
Update osr_util.cc

### DIFF
--- a/libcef/browser/osr/osr_util.cc
+++ b/libcef/browser/osr/osr_util.cc
@@ -10,15 +10,14 @@ namespace {
 
 // The rate at which new calls to OnPaint will be generated.
 const int kDefaultFrameRate = 30;
-const int kMaximumFrameRate = 60;
+
 
 }  // namespace
 
 int ClampFrameRate(int frame_rate) {
   if (frame_rate < 1)
     return kDefaultFrameRate;
-  else if (frame_rate > kMaximumFrameRate)
-    return kMaximumFrameRate;
+  
   return frame_rate;
 }
 


### PR DESCRIPTION
https://bitbucket.org/chromiumembedded/cef/issues/3077/offscreen-rendering-capped-at-60fps