### PR TITLE
Make cef_load_library cross-platform

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1847,7 +1847,6 @@ if (is_mac) {
     helper_sources = includes_common +
                      includes_mac +
                      gypi_paths2.includes_wrapper +
-                     gypi_paths2.includes_wrapper_mac +
                      gypi_paths2.shared_sources_common +
                      gypi_paths2.shared_sources_renderer +
                      gypi_paths2.shared_sources_mac_helper +
@@ -1861,7 +1860,6 @@ if (is_mac) {
     sources = includes_common +
               includes_mac +
               gypi_paths2.includes_wrapper +
-              gypi_paths2.includes_wrapper_mac +
               gypi_paths2.shared_sources_browser +
               gypi_paths2.shared_sources_common +
               gypi_paths2.shared_sources_mac +
@@ -1920,7 +1918,6 @@ if (is_mac) {
     helper_sources = includes_common +
                      includes_mac +
                      gypi_paths2.includes_wrapper +
-                     gypi_paths2.includes_wrapper_mac +
                      gypi_paths2.cefsimple_sources_mac_helper
     helper_defines = [
       "CEF_USE_SANDBOX",
@@ -1930,7 +1927,6 @@ if (is_mac) {
     sources = includes_common +
               includes_mac +
               gypi_paths2.includes_wrapper +
-              gypi_paths2.includes_wrapper_mac +
               gypi_paths2.cefsimple_sources_common +
               gypi_paths2.cefsimple_sources_mac
     deps = [
@@ -1997,7 +1993,6 @@ if (is_mac) {
     sources = includes_common +
               includes_mac +
               gypi_paths2.includes_wrapper +
-              gypi_paths2.includes_wrapper_mac +
               gypi_paths2.shared_sources_browser +
               gypi_paths2.shared_sources_common +
               gypi_paths2.shared_sources_mac +

--- a/cef_paths2.gypi
+++ b/cef_paths2.gypi
@@ -67,8 +67,6 @@
       'include/wrapper/cef_stream_resource_handler.h',
       'include/wrapper/cef_xml_object.h',
       'include/wrapper/cef_zip_archive.h',
-    ],
-    'includes_wrapper_mac': [
       'include/wrapper/cef_library_loader.h',
     ],
     'includes_win': [
@@ -158,10 +156,10 @@
       'libcef_dll/wrapper/cef_zip_archive.cc',
       'libcef_dll/wrapper/libcef_dll_wrapper.cc',
       'libcef_dll/wrapper/libcef_dll_wrapper2.cc',
+      'libcef_dll/wrapper/libcef_dll_dylib.cc',
     ],
     'libcef_dll_wrapper_sources_mac': [
       'libcef_dll/wrapper/cef_library_loader_mac.mm',
-      'libcef_dll/wrapper/libcef_dll_dylib.cc',
     ],
     'shared_sources_browser': [
       'tests/shared/browser/client_app_browser.cc',

--- a/include/wrapper/cef_library_loader.h
+++ b/include/wrapper/cef_library_loader.h
@@ -33,6 +33,12 @@
 
 #include "include/base/cef_build.h"
 
+#if defined(OS_WIN)
+  #define CEF_PATH_CHAR_T wchar_t
+#else
+  #define CEF_PATH_CHAR_T char
+#endif
+
 #ifdef __cplusplus
 #include <string>
 
@@ -45,7 +51,7 @@ extern "C" {
 // Load the CEF library at the specified |path|. Returns true (1) on
 // success and false (0) on failure.
 ///
-int cef_load_library(const char* path);
+int cef_load_library(const CEF_PATH_CHAR_T* path);
 
 ///
 // Unload the CEF library that was previously loaded. Returns true (1)

--- a/libcef_dll/CMakeLists.txt.in
+++ b/libcef_dll/CMakeLists.txt.in
@@ -28,7 +28,6 @@ set(CEF_TARGET libcef_dll_wrapper)
     'includes_capi',
     'autogen_capi_includes',
     'includes_wrapper',
-    'includes_wrapper_mac:MAC',
     'includes_win:WINDOWS',
     'includes_win_capi:WINDOWS',
     'includes_mac:MAC',

--- a/libcef_dll/wrapper/libcef_dll_dylib.cc
+++ b/libcef_dll/wrapper/libcef_dll_dylib.cc
@@ -9,11 +9,11 @@
 // implementations. See the translator.README.txt file in the tools directory
 // for more information.
 //
-// $hash=51090c9b8afc79ae98d70fe84c98bc7c8a433c3a$
+// $hash=48d9078932deb3674b8e0c48da5d51ae2121e971$
 //
 
-#include <dlfcn.h>
 #include <stdio.h>
+#include <system_error>
 
 #include "include/capi/cef_app_capi.h"
 #include "include/capi/cef_browser_capi.h"
@@ -71,17 +71,39 @@
 #include "include/internal/cef_trace_event_internal.h"
 #include "include/wrapper/cef_library_loader.h"
 
+#if defined(OS_WIN)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
 // GLOBAL WRAPPER FUNCTIONS - Do not edit by hand.
 
 namespace {
 
+#if defined(OS_WIN)
+inline std::string get_last_error_message() {
+  DWORD error_code = ::GetLastError();
+  return std::system_category().message(error_code);
+}
+#endif
+
 void* g_libcef_handle = nullptr;
 
-void* libcef_get_ptr(const char* path, const char* name) {
+void* libcef_get_ptr(const CEF_PATH_CHAR_T* path, const char* name) {
+#if defined(OS_WIN)
+  void* ptr = ::GetProcAddress((HMODULE)g_libcef_handle, name);
+  if (!ptr) {
+    fprintf(stderr, "GetProcAddress %ls: %s\n", path,
+            get_last_error_message().c_str());
+  }
+#else
   void* ptr = dlsym(g_libcef_handle, name);
   if (!ptr) {
     fprintf(stderr, "dlsym %s: %s\n", path, dlerror());
   }
+#endif
+
   return ptr;
 }
 
@@ -733,7 +755,7 @@ struct libcef_pointers {
     return 0;                                                       \
   }
 
-int libcef_init_pointers(const char* path) {
+int libcef_init_pointers(const CEF_PATH_CHAR_T* path) {
   INIT_ENTRY(cef_execute_process);
   INIT_ENTRY(cef_initialize);
   INIT_ENTRY(cef_shutdown);
@@ -935,15 +957,26 @@ int libcef_init_pointers(const char* path) {
 
 }  // namespace
 
-int cef_load_library(const char* path) {
+int cef_load_library(const CEF_PATH_CHAR_T* path) {
   if (g_libcef_handle)
     return 0;
 
+#if defined(OS_WIN)
+  g_libcef_handle = ::LoadLibraryExW(
+      path, nullptr,
+      LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
+  if (!g_libcef_handle) {
+    fprintf(stderr, "LoadLibraryExW %ls: %s\n", path,
+            get_last_error_message().c_str());
+    return 0;
+  }
+#else
   g_libcef_handle = dlopen(path, RTLD_LAZY | RTLD_LOCAL | RTLD_FIRST);
   if (!g_libcef_handle) {
     fprintf(stderr, "dlopen %s: %s\n", path, dlerror());
     return 0;
   }
+#endif
 
   if (!libcef_init_pointers(path)) {
     cef_unload_library();
@@ -956,10 +989,19 @@ int cef_load_library(const char* path) {
 int cef_unload_library() {
   int result = 0;
   if (g_libcef_handle) {
+#if defined(OS_WIN)
+    result = FreeLibrary((HMODULE)g_libcef_handle);
+    if (!result) {
+      fprintf(stderr, "FreeLibrary failed: %s\n",
+              get_last_error_message().c_str());
+    }
+#else
     result = !dlclose(g_libcef_handle);
     if (!result) {
       fprintf(stderr, "dlclose: %s\n", dlerror());
     }
+#endif
+
     g_libcef_handle = nullptr;
   }
   return result;

--- a/tools/make_distrib.py
+++ b/tools/make_distrib.py
@@ -1112,8 +1112,6 @@ elif platform == 'mac':
                         'include/', include_dir, options.quiet)
     transfer_gypi_files(cef_dir, cef_paths2['includes_mac_capi'], \
                         'include/', include_dir, options.quiet)
-    transfer_gypi_files(cef_dir, cef_paths2['includes_wrapper_mac'], \
-                        'include/', include_dir, options.quiet)
 
     # transfer libcef_dll_wrapper files
     transfer_gypi_files(cef_dir, cef_paths2['libcef_dll_wrapper_sources_mac'], \


### PR DESCRIPTION
https://bitbucket.org/chromiumembedded/cef/pull-requests/366

`cef_load_library` allows to load cef at runtime. Even though it was only indented to workaround macos sandbox restriction, it can also be very useful on Windows or Linux. For example, it allows the application to be distributed without cef and download cef on first run. Also it makes it easier to share one cef copy among multiple applications.

This PR makes `cef_load_library` work on Windows with the Win32 API `LoadLibraryExW`, and updates the file list so that it’s included in Linux and Windows dists.
