### PR TITLE
fixed memory leak in CefListValueImpl::SetInternal()

### DIFF
--- a/libcef/common/values_impl.cc
+++ b/libcef/common/values_impl.cc
@@ -1424,6 +1424,7 @@ bool CefListValueImpl::RemoveInternal(size_t index) {
 }
 
 base::Value* CefListValueImpl::SetInternal(size_t index, base::Value* value) {
+  const std::unique_ptr<base::Value> valuePtr{value};
   DCHECK(value);
 
   auto list = mutable_value()->GetListDeprecated();


### PR DESCRIPTION
`CefListValueImpl::SetInternal()` is leaking memory upon each call. this patch makes sure memory is released at the end of the function call.