### PR TITLE
Avoid generating an accidental UDL suffix

### DIFF
--- a/tools/make_ctocpp_impl.py
+++ b/tools/make_ctocpp_impl.py
@@ -104,7 +104,7 @@ def make_ctocpp_function_impl_new(clsname, name, func, base_scoped):
     result += '\n  // BEGIN DELETE BEFORE MODIFYING'
     result += '\n  // AUTO-GENERATED CONTENT'
     result += '\n  // COULD NOT IMPLEMENT DUE TO: ' + ', '.join(invalid)
-    result += '\n  #pragma message("Warning: "__FILE__": ' + name + ' is not implemented")'
+    result += '\n  #pragma message("Warning: " __FILE__ ": ' + name + ' is not implemented")'
     result += '\n  // END DELETE BEFORE MODIFYING'
     result += '\n}\n\n'
     return result


### PR DESCRIPTION
In the error case, we previously output a pragma with a string immediately followed by __FILE__ - but with no space between the string terminator and __FILE__, a compliant C++ compiler can interpret this as a user-defined literal suffix and end up failing to embed the intended information. We should add spaces here to ensure our generated code is standards-compliant.