### PR TITLE
Add CefDragData::GetFilePaths to return file paths (issue #3568)

### DIFF
--- a/include/capi/cef_drag_data_capi.h
+++ b/include/capi/cef_drag_data_capi.h
@@ -33,7 +33,7 @@
 // by hand. See the translator.README.txt file in the tools directory for
 // more information.
 //
-// $hash=a1ce746f0dd97d21973d4c80d8ef46391c0fd463$
+// $hash=8d00465ba004758f464cdb8b1fbd02cd26323ace$
 //
 
 #ifndef CEF_INCLUDE_CAPI_CEF_DRAG_DATA_CAPI_H_
@@ -148,6 +148,13 @@ typedef struct _cef_drag_data_t {
   ///
   int(CEF_CALLBACK* get_file_names)(struct _cef_drag_data_t* self,
                                     cef_string_list_t names);
+
+  ///
+  /// Retrieve the list of file paths that are being dragged into the browser
+  /// window.
+  ///
+  int(CEF_CALLBACK* get_file_paths)(struct _cef_drag_data_t* self,
+                                    cef_string_list_t paths);
 
   ///
   /// Set the link URL that is being dragged.

--- a/include/cef_api_hash.h
+++ b/include/cef_api_hash.h
@@ -42,13 +42,13 @@
 // way that may cause binary incompatibility with other builds. The universal
 // hash value will change if any platform is affected whereas the platform hash
 // values will change only if that particular platform is affected.
-#define CEF_API_HASH_UNIVERSAL "8aa786740cdcadf7b4f6dd3554343abae09ffdfd"
+#define CEF_API_HASH_UNIVERSAL "70f47a07411592c4e32d250a37971c10a4e41b5a"
 #if defined(OS_WIN)
-#define CEF_API_HASH_PLATFORM "f241d73d66f3b7f99aae58a0cc99be36beda4f4f"
+#define CEF_API_HASH_PLATFORM "acca1e62cab666a1d11fceecbdc79bdfdc4ec404"
 #elif defined(OS_MAC)
-#define CEF_API_HASH_PLATFORM "3708f34f956e6306d09989a88ff1dee9c8f7a2b5"
+#define CEF_API_HASH_PLATFORM "54970b1a356dfe149e92485d0580581892f17874"
 #elif defined(OS_LINUX)
-#define CEF_API_HASH_PLATFORM "cf413edb4edeb80d7d5c1173e342231b26808fce"
+#define CEF_API_HASH_PLATFORM "e2b605e557584f0a1b3c4e22a30eef9ab1d4726d"
 #endif
 
 #ifdef __cplusplus

--- a/include/cef_drag_data.h
+++ b/include/cef_drag_data.h
@@ -146,6 +146,13 @@ class CefDragData : public virtual CefBaseRefCounted {
   virtual bool GetFileNames(std::vector<CefString>& names) = 0;
 
   ///
+  /// Retrieve the list of file paths that are being dragged into the browser
+  /// window.
+  ///
+  /*--cef()--*/
+  virtual bool GetFilePaths(std::vector<CefString>& paths) = 0;
+
+  ///
   /// Set the link URL that is being dragged.
   ///
   /*--cef(optional_param=url)--*/

--- a/libcef/common/drag_data_impl.cc
+++ b/libcef/common/drag_data_impl.cc
@@ -125,10 +125,22 @@ bool CefDragDataImpl::GetFileNames(std::vector<CefString>& names) {
   std::vector<ui::FileInfo>::const_iterator it = data_.filenames.begin();
   for (; it != data_.filenames.end(); ++it) {
     auto name = it->display_name.value();
-    if (name.empty()) {
-      name = it->path.value();
-    }
     names.push_back(name);
+  }
+
+  return true;
+}
+
+bool CefDragDataImpl::GetFilePaths(std::vector<CefString>& paths) {
+  base::AutoLock lock_scope(lock_);
+  if (data_.filenames.empty()) {
+    return false;
+  }
+
+  std::vector<ui::FileInfo>::const_iterator it = data_.filenames.begin();
+  for (; it != data_.filenames.end(); ++it) {
+    auto path = it->path.value();
+    paths.push_back(path);
   }
 
   return true;

--- a/libcef/common/drag_data_impl.h
+++ b/libcef/common/drag_data_impl.h
@@ -37,6 +37,7 @@ class CefDragDataImpl : public CefDragData {
   CefString GetFileName() override;
   size_t GetFileContents(CefRefPtr<CefStreamWriter> writer) override;
   bool GetFileNames(std::vector<CefString>& names) override;
+  bool GetFilePaths(std::vector<CefString>& paths) override;
   void SetLinkURL(const CefString& url) override;
   void SetLinkTitle(const CefString& title) override;
   void SetLinkMetadata(const CefString& data) override;

--- a/libcef_dll/cpptoc/drag_data_cpptoc.cc
+++ b/libcef_dll/cpptoc/drag_data_cpptoc.cc
@@ -9,7 +9,7 @@
 // implementations. See the translator.README.txt file in the tools directory
 // for more information.
 //
-// $hash=dc5d0e68bdc9b8ec86dbc9b4fa0ddce6e4597006$
+// $hash=14322f994bd6eb8732cef20a3a70fc8ebbf32dea$
 //
 
 #include "libcef_dll/cpptoc/drag_data_cpptoc.h"
@@ -300,6 +300,38 @@ int CEF_CALLBACK drag_data_get_file_names(struct _cef_drag_data_t* self,
   return _retval;
 }
 
+int CEF_CALLBACK
+drag_data_get_file_paths(struct _cef_drag_data_t* self,
+                         cef_string_list_t paths) {
+  shutdown_checker::AssertNotShutdown();
+
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  DCHECK(self);
+  if (!self) {
+    return 0;
+  }
+  // Verify param: paths; type: string_vec_byref
+  DCHECK(paths);
+  if (!paths) {
+    return 0;
+  }
+
+  // Translate param: paths; type: string_vec_byref
+  std::vector<CefString> pathsList;
+  transfer_string_list_contents(paths, pathsList);
+
+  // Execute
+  bool _retval = CefDragDataCppToC::Get(self)->GetFilePaths(pathsList);
+
+  // Restore param: paths; type: string_vec_byref
+  cef_string_list_clear(paths);
+  transfer_string_list_contents(pathsList, paths);
+
+  // Return type: bool
+  return _retval;
+}
+
 void CEF_CALLBACK drag_data_set_link_url(struct _cef_drag_data_t* self,
                                          const cef_string_t* url) {
   shutdown_checker::AssertNotShutdown();
@@ -520,6 +552,7 @@ CefDragDataCppToC::CefDragDataCppToC() {
   GetStruct()->get_file_name = drag_data_get_file_name;
   GetStruct()->get_file_contents = drag_data_get_file_contents;
   GetStruct()->get_file_names = drag_data_get_file_names;
+  GetStruct()->get_file_paths = drag_data_get_file_paths;
   GetStruct()->set_link_url = drag_data_set_link_url;
   GetStruct()->set_link_title = drag_data_set_link_title;
   GetStruct()->set_link_metadata = drag_data_set_link_metadata;

--- a/libcef_dll/ctocpp/drag_data_ctocpp.cc
+++ b/libcef_dll/ctocpp/drag_data_ctocpp.cc
@@ -9,7 +9,7 @@
 // implementations. See the translator.README.txt file in the tools directory
 // for more information.
 //
-// $hash=62aa3d486f9f864b4a5a68ebdf4ebb0695c017d1$
+// $hash=1dadac1c1138021a5f38e52ccb8f9863f5a387b5$
 //
 
 #include "libcef_dll/ctocpp/drag_data_ctocpp.h"
@@ -299,6 +299,38 @@ bool CefDragDataCToCpp::GetFileNames(std::vector<CefString>& names) {
     names.clear();
     transfer_string_list_contents(namesList, names);
     cef_string_list_free(namesList);
+  }
+
+  // Return type: bool
+  return _retval ? true : false;
+}
+
+NO_SANITIZE("cfi-icall")
+bool CefDragDataCToCpp::GetFilePaths(std::vector<CefString>& paths) {
+  shutdown_checker::AssertNotShutdown();
+
+  cef_drag_data_t* _struct = GetStruct();
+  if (CEF_MEMBER_MISSING(_struct, get_file_paths)) {
+    return false;
+  }
+
+  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
+
+  // Translate param: paths; type: string_vec_byref
+  cef_string_list_t pathsList = cef_string_list_alloc();
+  DCHECK(pathsList);
+  if (pathsList) {
+    transfer_string_list_contents(paths, pathsList);
+  }
+
+  // Execute
+  int _retval = _struct->get_file_paths(_struct, pathsList);
+
+  // Restore param:paths; type: string_vec_byref
+  if (pathsList) {
+    paths.clear();
+    transfer_string_list_contents(pathsList, paths);
+    cef_string_list_free(pathsList);
   }
 
   // Return type: bool

--- a/libcef_dll/ctocpp/drag_data_ctocpp.h
+++ b/libcef_dll/ctocpp/drag_data_ctocpp.h
@@ -9,7 +9,7 @@
 // implementations. See the translator.README.txt file in the tools directory
 // for more information.
 //
-// $hash=7a8ec7b7c1010725596b1a64eb325b0e75ea34b7$
+// $hash=fee8d107d6baed8cb7d838613ab4b95134e04c59$
 //
 
 #ifndef CEF_LIBCEF_DLL_CTOCPP_DRAG_DATA_CTOCPP_H_
@@ -49,6 +49,7 @@ class CefDragDataCToCpp : public CefCToCppRefCounted<CefDragDataCToCpp,
   CefString GetFileName() override;
   size_t GetFileContents(CefRefPtr<CefStreamWriter> writer) override;
   bool GetFileNames(std::vector<CefString>& names) override;
+  bool GetFilePaths(std::vector<CefString>& paths) override;
   void SetLinkURL(const CefString& url) override;
   void SetLinkTitle(const CefString& title) override;
   void SetLinkMetadata(const CefString& data) override;


### PR DESCRIPTION
- Add GetFilePaths to explicitly return drag file paths
- GetFileNames returns just the display names and will not fallback to path if display name is empty.