### PR TITLE
Added option to disable signal handlers on POSIX systems

### DIFF
--- a/include/internal/cef_types.h
+++ b/include/internal/cef_types.h
@@ -486,6 +486,13 @@ typedef struct _cef_settings_t {
   /// Windows.
   ///
   int chrome_app_icon_id;
+
+#if defined(OS_POSIX) && !defined(OS_ANDROID)
+  ///
+  /// Specify whether signal handlers must be disabled on POSIX systems.
+  ///
+  bool disable_signal_handlers;
+#endif
 } cef_settings_t;
 
 ///

--- a/libcef/browser/main_runner.cc
+++ b/libcef/browser/main_runner.cc
@@ -101,7 +101,8 @@ bool CefMainRunner::Initialize(CefSettings* settings,
   application_ = application;
 
   exit_code_ =
-      ContentMainInitialize(args, windows_sandbox_info, &settings->no_sandbox, settings->disable_signal_handlers);
+      ContentMainInitialize(args, windows_sandbox_info, &settings->no_sandbox,
+                            settings->disable_signal_handlers);
   if (exit_code_ >= 0) {
     LOG(ERROR) << "ContentMainInitialize failed with exit code " << exit_code_;
     return false;

--- a/libcef/browser/main_runner.cc
+++ b/libcef/browser/main_runner.cc
@@ -101,7 +101,7 @@ bool CefMainRunner::Initialize(CefSettings* settings,
   application_ = application;
 
   exit_code_ =
-      ContentMainInitialize(args, windows_sandbox_info, &settings->no_sandbox);
+      ContentMainInitialize(args, windows_sandbox_info, &settings->no_sandbox, settings->disable_signal_handlers);
   if (exit_code_ >= 0) {
     LOG(ERROR) << "ContentMainInitialize failed with exit code " << exit_code_;
     return false;
@@ -253,7 +253,8 @@ int CefMainRunner::RunAsHelperProcess(const CefMainArgs& args,
 
 int CefMainRunner::ContentMainInitialize(const CefMainArgs& args,
                                          void* windows_sandbox_info,
-                                         int* no_sandbox) {
+                                         int* no_sandbox,
+                                         bool disable_signal_handlers) {
   BeforeMainInitialize(args);
 
   main_delegate_ =
@@ -276,6 +277,10 @@ int CefMainRunner::ContentMainInitialize(const CefMainArgs& args,
 #else
   main_params.argc = args.argc;
   main_params.argv = const_cast<const char**>(args.argv);
+#endif
+
+#if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_ANDROID)
+  main_params.disable_signal_handlers = disable_signal_handlers;
 #endif
 
   return content::ContentMainInitialize(std::move(main_params),

--- a/libcef/browser/main_runner.h
+++ b/libcef/browser/main_runner.h
@@ -62,7 +62,8 @@ class CefMainRunner final {
   // Called from Initialize().
   int ContentMainInitialize(const CefMainArgs& args,
                             void* windows_sandbox_info,
-                            int* no_sandbox);
+                            int* no_sandbox,
+                            bool disable_signal_handlers);
   int ContentMainRun(bool* initialized, base::OnceClosure context_initialized);
 
   static void BeforeMainInitialize(const CefMainArgs& args);

--- a/patch/patches/content_main_654986.patch
+++ b/patch/patches/content_main_654986.patch
@@ -12,7 +12,7 @@ index 79ba3ac1913f8..46bcb4366d2f8 100644
    if (main_argv)
      setproctitle_init(main_argv);
 diff --git content/app/content_main.cc content/app/content_main.cc
-index 96c28a7ce3183..cc1b825f1b500 100644
+index 96c28a7ce3183..8a396ce7adf86 100644
 --- content/app/content_main.cc
 +++ content/app/content_main.cc
 @@ -174,11 +174,8 @@ ContentMainParams::~ContentMainParams() = default;
@@ -39,41 +39,13 @@ index 96c28a7ce3183..cc1b825f1b500 100644
  
    // A flag to indicate whether Main() has been called before. On Android, we
    // may re-run Main() without restarting the browser process. This flag
-@@ -252,21 +246,23 @@ RunContentProcess(ContentMainParams params,
- // On Android setlocale() is not supported, and we don't override the signal
- // handlers so we can get a stack trace when crashing.
- #if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_ANDROID)
--    // Set C library locale to make sure CommandLine can parse
--    // argument values in the correct encoding and to make sure
--    // generated file names (think downloads) are in the file system's
--    // encoding.
--    setlocale(LC_ALL, "");
--    // For numbers we never want the C library's locale sensitive
--    // conversion from number to string because the only thing it
--    // changes is the decimal separator which is not good enough for
--    // the UI and can be harmful elsewhere. User interface number
--    // conversions need to go through ICU. Other conversions need to
--    // be locale insensitive so we force the number locale back to the
--    // default, "C", locale.
--    setlocale(LC_NUMERIC, "C");
--
+@@ -266,7 +260,9 @@ RunContentProcess(ContentMainParams params,
+     // default, "C", locale.
+     setlocale(LC_NUMERIC, "C");
+ 
 -    SetupSignalHandlers();
 +    if (!params.disable_signal_handlers) {
-+        // Set C library locale to make sure CommandLine can parse
-+        // argument values in the correct encoding and to make sure
-+        // generated file names (think downloads) are in the file system's
-+        // encoding.
-+        setlocale(LC_ALL, "");
-+        // For numbers we never want the C library's locale sensitive
-+        // conversion from number to string because the only thing it
-+        // changes is the decimal separator which is not good enough for
-+        // the UI and can be harmful elsewhere. User interface number
-+        // conversions need to go through ICU. Other conversions need to
-+        // be locale insensitive so we force the number locale back to the
-+        // default, "C", locale.
-+        setlocale(LC_NUMERIC, "C");
-+
-+        SetupSignalHandlers();
++      SetupSignalHandlers();
 +    }
  #endif
  
@@ -142,10 +114,10 @@ index 96c28a7ce3183..cc1b825f1b500 100644
  }
  
 diff --git content/app/content_main_runner_impl.cc content/app/content_main_runner_impl.cc
-index 78b9930f1ca5c..1d93552c3da25 100644
+index 5e4c1f8d6c872..6df7bdba1cff7 100644
 --- content/app/content_main_runner_impl.cc
 +++ content/app/content_main_runner_impl.cc
-@@ -52,6 +52,7 @@
+@@ -47,6 +47,7 @@
  #include "base/task/thread_pool/thread_pool_instance.h"
  #include "base/threading/hang_watcher.h"
  #include "base/threading/platform_thread.h"
@@ -153,7 +125,7 @@ index 78b9930f1ca5c..1d93552c3da25 100644
  #include "base/time/time.h"
  #include "base/trace_event/trace_event.h"
  #include "build/build_config.h"
-@@ -1342,6 +1343,11 @@ void ContentMainRunnerImpl::Shutdown() {
+@@ -1349,6 +1350,11 @@ void ContentMainRunnerImpl::Shutdown() {
    is_shutdown_ = true;
  }
  

--- a/patch/patches/content_main_654986.patch
+++ b/patch/patches/content_main_654986.patch
@@ -12,7 +12,7 @@ index 79ba3ac1913f8..46bcb4366d2f8 100644
    if (main_argv)
      setproctitle_init(main_argv);
 diff --git content/app/content_main.cc content/app/content_main.cc
-index 96c28a7ce3183..3d60ab170e9a5 100644
+index 96c28a7ce3183..cc1b825f1b500 100644
 --- content/app/content_main.cc
 +++ content/app/content_main.cc
 @@ -174,11 +174,8 @@ ContentMainParams::~ContentMainParams() = default;
@@ -39,7 +39,46 @@ index 96c28a7ce3183..3d60ab170e9a5 100644
  
    // A flag to indicate whether Main() has been called before. On Android, we
    // may re-run Main() without restarting the browser process. This flag
-@@ -274,14 +268,6 @@ RunContentProcess(ContentMainParams params,
+@@ -252,21 +246,23 @@ RunContentProcess(ContentMainParams params,
+ // On Android setlocale() is not supported, and we don't override the signal
+ // handlers so we can get a stack trace when crashing.
+ #if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_ANDROID)
+-    // Set C library locale to make sure CommandLine can parse
+-    // argument values in the correct encoding and to make sure
+-    // generated file names (think downloads) are in the file system's
+-    // encoding.
+-    setlocale(LC_ALL, "");
+-    // For numbers we never want the C library's locale sensitive
+-    // conversion from number to string because the only thing it
+-    // changes is the decimal separator which is not good enough for
+-    // the UI and can be harmful elsewhere. User interface number
+-    // conversions need to go through ICU. Other conversions need to
+-    // be locale insensitive so we force the number locale back to the
+-    // default, "C", locale.
+-    setlocale(LC_NUMERIC, "C");
+-
+-    SetupSignalHandlers();
++    if (!params.disable_signal_handlers) {
++        // Set C library locale to make sure CommandLine can parse
++        // argument values in the correct encoding and to make sure
++        // generated file names (think downloads) are in the file system's
++        // encoding.
++        setlocale(LC_ALL, "");
++        // For numbers we never want the C library's locale sensitive
++        // conversion from number to string because the only thing it
++        // changes is the decimal separator which is not good enough for
++        // the UI and can be harmful elsewhere. User interface number
++        // conversions need to go through ICU. Other conversions need to
++        // be locale insensitive so we force the number locale back to the
++        // default, "C", locale.
++        setlocale(LC_NUMERIC, "C");
++
++        SetupSignalHandlers();
++    }
+ #endif
+ 
+ #if BUILDFLAG(IS_WIN)
+@@ -274,14 +270,6 @@ RunContentProcess(ContentMainParams params,
  #endif
  
  #if BUILDFLAG(IS_MAC)
@@ -54,7 +93,7 @@ index 96c28a7ce3183..3d60ab170e9a5 100644
      InitializeMac();
  #endif
  
-@@ -329,12 +315,46 @@ RunContentProcess(ContentMainParams params,
+@@ -329,12 +317,46 @@ RunContentProcess(ContentMainParams params,
  
    if (IsSubprocess())
      CommonSubprocessInit();
@@ -149,10 +188,22 @@ index cbbc2f3ec12fa..f097b3cdded2f 100644
    int RunBrowser(MainFunctionParams main_function_params,
                   bool start_minimal_browser);
 diff --git content/public/app/content_main.h content/public/app/content_main.h
-index 7f9b515297357..89b52e34fa31a 100644
+index 7f9b515297357..5606867e43780 100644
 --- content/public/app/content_main.h
 +++ content/public/app/content_main.h
-@@ -94,6 +94,13 @@ struct CONTENT_EXPORT ContentMainParams {
+@@ -66,6 +66,11 @@ struct CONTENT_EXPORT ContentMainParams {
+   // are left uninitialized.
+   bool minimal_browser_mode = false;
+ 
++#if BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_ANDROID)
++  // Indicates whether to disable signal handlers
++  bool disable_signal_handlers = false;
++#endif
++
+ #if BUILDFLAG(IS_MAC)
+   // The outermost autorelease pool to pass to main entry points.
+   STACK_ALLOCATED_IGNORE("https://crbug.com/1424190")
+@@ -94,6 +99,13 @@ struct CONTENT_EXPORT ContentMainParams {
    }
  };
  


### PR DESCRIPTION
Added an option to fix https://github.com/chromiumembedded/java-cef/issues/477.

~~Need to test it, I'll do that tomorrow.~~

~~Also need to rebase to the latest CEF. I did this on 126.X since this is the current supported version by JCEF.~~

Please give your thoughts 😄 