### PR TITLE
Iterate through the correct range when converting AXState

### DIFF
--- a/libcef/browser/osr/osr_accessibility_util.cc
+++ b/libcef/browser/osr/osr_accessibility_util.cc
@@ -42,8 +42,8 @@ CefRefPtr<CefListValue> ToCefValue(uint32_t state) {
 
   int index = 0;
   // Iterate and find which states are set.
-  for (unsigned i = static_cast<unsigned>(ax::mojom::Role::kMinValue) + 1;
-       i <= static_cast<unsigned>(ax::mojom::Role::kMaxValue); i++) {
+  for (unsigned i = static_cast<unsigned>(ax::mojom::State::kNone) + 1;
+       i <= static_cast<unsigned>(ax::mojom::State::kMaxValue); i++) {
     if (state & (1 << i)) {
       value->SetString(index++, ToString(static_cast<ax::mojom::State>(i)));
     }


### PR DESCRIPTION
The code currently uses `ax::mojom::Role` for start and end range instead of `ax::mojom::State` which results in bit-shifting 1 by a number larger than the 32-bit state can represent.