### PR TITLE
ceftests: Fix crash when run OSRTest (see #3932)

### DIFF
--- a/tests/ceftests/os_rendering_unittest.cc
+++ b/tests/ceftests/os_rendering_unittest.cc
@@ -1669,6 +1669,10 @@ class OSRTestHandler : public RoutingTestHandler,
   }
 
   void SendTouchEvents(std::vector<CefTouchEvent> touch_events) {
+    if (!GetBrowser() || !GetBrowser()->GetHost()) {
+      return;
+    }
+
     auto host = GetBrowser()->GetHost();
     for (const auto& te : touch_events) {
       host->SendTouchEvent(te);


### PR DESCRIPTION
OSRTestHandler::SendTouchEvents() may be called after the browser has been destroyed.