### PR TITLE
Force use-angle=gl-egl and ozone-platform=X11 for Linux OSR shared texture mode

### DIFF
--- a/tests/shared/browser/client_app_browser.cc
+++ b/tests/shared/browser/client_app_browser.cc
@@ -75,15 +75,25 @@ void ClientAppBrowser::OnBeforeCommandLineProcessing(
 
 #if defined(OS_LINUX)
     // On Linux, in off screen rendering (OSR) shared texture mode, we must
-    // ensure that ANGLE uses the EGL backend. Without this, DMABUF-based
-    // rendering will fail. The Chromium fallback path uses X11 pixmaps, which
-    // only work on Mesa drivers (e.g., AMD and Intel). While Mesa supports
-    // DMABUFs via both EGL and pixmaps, the EGL/DMABUF path is more robust and
-    // is required for compatibility with other drivers like NVIDIA that do not
-    // support pixmaps.
+    // ensure that ANGLE uses the EGL backend. Without this, DMABUF based
+    // rendering will fail. The Chromium fallback path uses X11 pixmaps,
+    // which are only supported by Mesa drivers (e.g., AMD and Intel).
+    //
+    // While Mesa supports DMABUFs via both EGL and pixmaps, the EGL based
+    // DMA BUF import path is more robust and required for compatibility with
+    // drivers like NVIDIA that do not support pixmaps.
+    //
+    // We also append the kOzonePlatform switch with value x11 to ensure
+    // that X11 semantics are preserved, which is necessary for compatibility
+    // with some GDK/X11 integrations (e.g. Wayland with AMD).
     if (command_line->HasSwitch(switches::kOffScreenRenderingEnabled) &&
         command_line->HasSwitch(switches::kSharedTextureEnabled)) {
-      command_line->AppendSwitchWithValue("use-angle", "gl-egl");
+      if (!command_line->HasSwitch(switches::kUseAngle)) {
+        command_line->AppendSwitchWithValue(switches::kUseAngle, "gl-egl");
+      }
+      if (!command_line->HasSwitch(switches::kOzonePlatform)) {
+        command_line->AppendSwitchWithValue(switches::kOzonePlatform, "X11");
+      }
     }
 #endif
 

--- a/tests/shared/browser/client_app_browser.cc
+++ b/tests/shared/browser/client_app_browser.cc
@@ -73,6 +73,20 @@ void ClientAppBrowser::OnBeforeCommandLineProcessing(
     command_line->AppendSwitch("use-mock-keychain");
 #endif
 
+#if defined(OS_LINUX)
+    // On Linux, in off screen rendering (OSR) shared texture mode, we must
+    // ensure that ANGLE uses the EGL backend. Without this, DMABUF-based
+    // rendering will fail. The Chromium fallback path uses X11 pixmaps, which
+    // only work on Mesa drivers (e.g., AMD and Intel). While Mesa supports
+    // DMABUFs via both EGL and pixmaps, the EGL/DMABUF path is more robust and
+    // is required for compatibility with other drivers like NVIDIA that do not
+    // support pixmaps.
+    if (command_line->HasSwitch(switches::kOffScreenRenderingEnabled) &&
+        command_line->HasSwitch(switches::kSharedTextureEnabled)) {
+      command_line->AppendSwitchWithValue("use-angle", "gl-egl");
+    }
+#endif
+
     DelegateSet::iterator it = delegates_.begin();
     for (; it != delegates_.end(); ++it) {
       (*it)->OnBeforeCommandLineProcessing(this, command_line);

--- a/tests/shared/common/client_switches.cc
+++ b/tests/shared/common/client_switches.cc
@@ -61,5 +61,7 @@ const char kAcceptsFirstMouse[] = "accepts-first-mouse";
 const char kUseAlloyStyle[] = "use-alloy-style";
 const char kUseChromeStyleWindow[] = "use-chrome-style-window";
 const char kShowOverlayBrowser[] = "show-overlay-browser";
+const char kUseAngle[] = "use-angle";
+const char kOzonePlatform[] = "ozone-platform";
 
 }  // namespace client::switches

--- a/tests/shared/common/client_switches.h
+++ b/tests/shared/common/client_switches.h
@@ -55,6 +55,8 @@ extern const char kAcceptsFirstMouse[];
 extern const char kUseAlloyStyle[];
 extern const char kUseChromeStyleWindow[];
 extern const char kShowOverlayBrowser[];
+extern const char kUseAngle[];
+extern const char kOzonePlatform[];
 
 }  // namespace client::switches
 


### PR DESCRIPTION
When off screen rendering (OSR) and shared texture mode are both enabled on Linux, DMABUF based rendering requires ANGLE's EGL backend (use-angle=gl-egl) to work correctly.

Without this switch, Chromium falls back to the pixmap codepath, which only works on some Mesa drivers (e.g., Intel and AMD). To support broader compatibility including NVIDIA we explicitly set use-angle=gl-egl. We have verified that this works correctly on both NVIDIA GPUs (latest drivers 565+) and AMD.

In addition we also need to append the ozone-platform=X11 switch to avoid Gdk assertions in certain Wayland environments like those with AMD GPUs.  Example assertions invalid cast from GdkWaylandScreen to GdkX11Screen etc.

Please note that this patch itself is not sufficient. We still need to pass in a different buffer usage flag in the shared texture
mode https://source.chromium.org/chromium/chromium/src/+/main:media/video/renderable_gpu_memory_buffer_video_frame_pool.cc;l=196;drc=e65323be17a0ba06198d18b0a8bf5ae594e10348;bpv=0;bpt=1 as GBM_BO_USE_LINEAR doesn't work on 
Nvidia drivers.

Fixes #3953