### PR TITLE
Convert std::stringstream to C++20 std::format (see #3590)

### DIFF
--- a/libcef/browser/xml_reader_impl.cc
+++ b/libcef/browser/xml_reader_impl.cc
@@ -4,6 +4,8 @@
 
 #include "cef/libcef/browser/xml_reader_impl.h"
 
+#include <format>
+
 #include "base/logging.h"
 #include "base/notreached.h"
 #include "cef/include/cef_stream.h"
@@ -62,13 +64,13 @@ void XMLCALL xml_error_callback(void* arg,
     error_str.resize(error_str.length() - 1);
   }
 
-  std::stringstream ss;
-  ss << error_str << ", line " << xmlTextReaderLocatorLineNumber(locator);
+  auto formatted_error = std::format("{}, line {}", error_str,
+                                     xmlTextReaderLocatorLineNumber(locator));
 
-  LOG(INFO) << ss.str();
+  LOG(INFO) << formatted_error;
 
   CefRefPtr<CefXmlReaderImpl> impl(static_cast<CefXmlReaderImpl*>(arg));
-  impl->AppendError(ss.str());
+  impl->AppendError(formatted_error);
 }
 
 /**
@@ -90,13 +92,12 @@ void XMLCALL xml_structured_error_callback(void* userData,
     error_str.resize(error_str.length() - 1);
   }
 
-  std::stringstream ss;
-  ss << error_str << ", line " << error->line;
+  auto formatted_error = std::format("{}, line {}", error_str, error->line);
 
-  LOG(INFO) << ss.str();
+  LOG(INFO) << formatted_error;
 
   CefRefPtr<CefXmlReaderImpl> impl(static_cast<CefXmlReaderImpl*>(userData));
-  impl->AppendError(ss.str());
+  impl->AppendError(formatted_error);
 }
 
 CefString xmlCharToString(const xmlChar* xmlStr, bool free) {
@@ -205,7 +206,7 @@ bool CefXmlReaderImpl::HasError() {
     return false;
   }
 
-  return !error_buf_.str().empty();
+  return !error_buf_.empty();
 }
 
 CefString CefXmlReaderImpl::GetError() {
@@ -213,7 +214,7 @@ CefString CefXmlReaderImpl::GetError() {
     return CefString();
   }
 
-  return error_buf_.str();
+  return error_buf_;
 }
 
 CefXmlReader::NodeType CefXmlReaderImpl::GetType() {
@@ -476,10 +477,10 @@ bool CefXmlReaderImpl::MoveToCarryingElement() {
 }
 
 void CefXmlReaderImpl::AppendError(const CefString& error_str) {
-  if (!error_buf_.str().empty()) {
-    error_buf_ << L"\n";
+  if (!error_buf_.empty()) {
+    error_buf_ += '\n';
   }
-  error_buf_ << error_str.ToString();
+  error_buf_ += error_str.ToString();
 }
 
 bool CefXmlReaderImpl::VerifyContext() {

--- a/libcef/browser/xml_reader_impl.h
+++ b/libcef/browser/xml_reader_impl.h
@@ -8,7 +8,7 @@
 
 #include <libxml/xmlreader.h>
 
-#include <sstream>
+#include <string>
 
 #include "base/threading/platform_thread.h"
 #include "cef/include/cef_xml_reader.h"
@@ -67,7 +67,7 @@ class CefXmlReaderImpl : public CefXmlReader {
   base::PlatformThreadId supported_thread_id_;
   CefRefPtr<CefStreamReader> stream_;
   xmlTextReaderPtr reader_ = nullptr;
-  std::stringstream error_buf_;
+  std::string error_buf_;
 
   IMPLEMENT_REFCOUNTING(CefXmlReaderImpl);
 };

--- a/libcef/browser/zip_reader_impl.h
+++ b/libcef/browser/zip_reader_impl.h
@@ -6,8 +6,6 @@
 #define CEF_LIBCEF_BROWSER_ZIP_READER_IMPL_H_
 #pragma once
 
-#include <sstream>
-
 #include "base/threading/platform_thread.h"
 #include "cef/include/cef_zip_reader.h"
 #include "third_party/zlib/contrib/minizip/unzip.h"

--- a/libcef/common/parser_impl.cc
+++ b/libcef/common/parser_impl.cc
@@ -2,7 +2,7 @@
 // reserved. Use of this source code is governed by a BSD-style license that can
 // be found in the LICENSE file.
 
-#include <sstream>
+#include <string>
 
 #include "base/base64.h"
 #include "base/strings/escape.h"
@@ -67,29 +67,32 @@ bool CefCreateURL(const CefURLParts& parts, CefString& url) {
   if (!spec.empty()) {
     gurl = GURL(spec);
   } else if (!scheme.empty() && !host.empty()) {
-    std::stringstream ss;
-    ss << scheme << "://";
+    std::string url_str = scheme + "://";
     if (!username.empty()) {
-      ss << username;
+      url_str += username;
       if (!password.empty()) {
-        ss << ":" << password;
+        url_str += ':';
+        url_str += password;
       }
-      ss << "@";
+      url_str += '@';
     }
-    ss << host;
+    url_str += host;
     if (!port.empty()) {
-      ss << ":" << port;
+      url_str += ':';
+      url_str += port;
     }
     if (!path.empty()) {
-      ss << path;
+      url_str += path;
     }
     if (!query.empty()) {
-      ss << "?" << query;
+      url_str += '?';
+      url_str += query;
     }
     if (!fragment.empty()) {
-      ss << "#" << fragment;
+      url_str += '#';
+      url_str += fragment;
     }
-    gurl = GURL(ss.str());
+    gurl = GURL(url_str);
   }
 
   if (gurl.is_valid()) {

--- a/libcef_dll/base/cef_logging.cc
+++ b/libcef_dll/base/cef_logging.cc
@@ -24,9 +24,9 @@
 #include <mach/mach_time.h>
 #endif
 
-#include <iomanip>
+#include <format>
 #include <iostream>
-#include <sstream>
+#include <string>
 
 #include "include/base/cef_immediate_crash.h"
 
@@ -353,31 +353,30 @@ void ScopedEarlySupport::log(const char* file,
                            std::min(std::size_t{6}, strlen(file)))
                      : file;
 
-  std::stringstream stream;
-
-  stream << '[';
+  std::string log_line = "[";
   if (config.log_prefix) {
-    stream << config.log_prefix << ':';
+    log_line += config.log_prefix;
+    log_line += ':';
   }
   if (config.log_process_id) {
 #if defined(OS_WIN)
-    stream << ::GetCurrentProcessId() << ':';
+    log_line += std::format("{}:", ::GetCurrentProcessId());
 #elif defined(OS_POSIX)
-    stream << getpid() << ':';
+    log_line += std::format("{}:", getpid());
 #else
 #error Unsupported platform
 #endif
   }
   if (config.log_thread_id) {
 #if defined(OS_WIN)
-    stream << ::GetCurrentThreadId() << ':';
+    log_line += std::format("{}:", ::GetCurrentThreadId());
 #elif defined(OS_APPLE)
     uint64_t tid;
     if (pthread_threadid_np(nullptr, &tid) == 0) {
-      stream << tid << ':';
+      log_line += std::format("{}:", tid);
     }
 #elif defined(OS_POSIX)
-    stream << pthread_self() << ':';
+    log_line += std::format("{}:", pthread_self());
 #else
 #error Unsupported platform
 #endif
@@ -386,11 +385,10 @@ void ScopedEarlySupport::log(const char* file,
 #if defined(OS_WIN)
     SYSTEMTIME local_time;
     GetLocalTime(&local_time);
-    stream << std::setfill('0') << std::setw(2) << local_time.wMonth
-           << std::setw(2) << local_time.wDay << '/' << std::setw(2)
-           << local_time.wHour << std::setw(2) << local_time.wMinute
-           << std::setw(2) << local_time.wSecond << '.' << std::setw(3)
-           << local_time.wMilliseconds << ':';
+    log_line +=
+        std::format("{:02}{:02}/{:02}{:02}{:02}.{:03}:", local_time.wMonth,
+                    local_time.wDay, local_time.wHour, local_time.wMinute,
+                    local_time.wSecond, local_time.wMilliseconds);
 #elif defined(OS_POSIX)
     timeval tv;
     gettimeofday(&tv, nullptr);
@@ -398,26 +396,23 @@ void ScopedEarlySupport::log(const char* file,
     struct tm local_time;
     localtime_r(&t, &local_time);
     struct tm* tm_time = &local_time;
-    stream << std::setfill('0') << std::setw(2) << 1 + tm_time->tm_mon
-           << std::setw(2) << tm_time->tm_mday << '/' << std::setw(2)
-           << tm_time->tm_hour << std::setw(2) << tm_time->tm_min
-           << std::setw(2) << tm_time->tm_sec << '.' << std::setw(6)
-           << tv.tv_usec << ':';
+    log_line +=
+        std::format("{:02}{:02}/{:02}{:02}{:02}.{:06}:", 1 + tm_time->tm_mon,
+                    tm_time->tm_mday, tm_time->tm_hour, tm_time->tm_min,
+                    tm_time->tm_sec, tv.tv_usec);
 #else
 #error Unsupported platform
 #endif
   }
   if (config.log_tickcount) {
-    stream << TickCount() << ':';
+    log_line += std::format("{}:", TickCount());
   }
   if (severity >= 0) {
-    stream << log_severity_name(severity);
+    log_line += log_severity_name(severity);
   } else {
-    stream << "VERBOSE" << -severity;
+    log_line += std::format("VERBOSE{}", -severity);
   }
-  stream << ":" << filename << ":" << line << "] " << message;
-
-  const std::string& log_line = stream.str();
+  log_line += std::format(":{}:{}] {}", filename, line, message);
 
   if (!config.formatted_log_handler ||
       !config.formatted_log_handler(log_line.c_str())) {
@@ -521,17 +516,15 @@ std::string SystemErrorCodeToString(SystemErrorCode error_code) {
   DWORD flags = FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
   DWORD len = FormatMessageA(flags, NULL, error_code, 0, msgbuf,
                              static_cast<DWORD>(std::size(msgbuf)), NULL);
-  std::stringstream ss;
   if (len) {
     std::string s(msgbuf);
     // Messages returned by system end with line breaks.
     s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
-    ss << s << " (0x" << std::hex << error_code << ")";
+    return std::format("{} ({:#x})", s, error_code);
   } else {
-    ss << "Error (0x" << std::hex << GetLastError()
-       << ") while retrieving error. (0x" << error_code << ")";
+    return std::format("Error ({:#x}) while retrieving error. ({:#x})",
+                       GetLastError(), error_code);
   }
-  return ss.str();
 }
 #elif defined(OS_POSIX)
 std::string SystemErrorCodeToString(SystemErrorCode error_code) {

--- a/libcef_dll/wrapper/cef_scoped_library_loader_mac.mm
+++ b/libcef_dll/wrapper/cef_scoped_library_loader_mac.mm
@@ -6,8 +6,8 @@
 #include <mach-o/dyld.h>
 #include <stdio.h>
 
+#include <format>
 #include <memory>
-#include <sstream>
 
 #include "include/wrapper/cef_library_loader.h"
 
@@ -38,10 +38,9 @@ std::string GetFrameworkPath(bool helper) {
   }
 
   // Append the relative path to the framework.
-  std::stringstream ss;
-  ss << parent_dir << "/" << (helper ? kPathFromHelperExe : kPathFromMainExe)
-     << "/" << kFrameworkPath;
-  return ss.str();
+  return std::format("{}/{}/{}", parent_dir,
+                     helper ? kPathFromHelperExe : kPathFromMainExe,
+                     kFrameworkPath);
 }
 
 }  // namespace

--- a/libcef_dll/wrapper/cef_scoped_sandbox_context_mac.mm
+++ b/libcef_dll/wrapper/cef_scoped_sandbox_context_mac.mm
@@ -7,8 +7,8 @@
 #include <mach-o/dyld.h>
 #include <stdio.h>
 
+#include <format>
 #include <memory>
-#include <sstream>
 
 #include "include/cef_sandbox_mac.h"
 
@@ -39,9 +39,7 @@ std::string GetLibraryPath() {
   }
 
   // Append the relative path to the library.
-  std::stringstream ss;
-  ss << parent_dir << "/" << kLibraryPath;
-  return ss.str();
+  return std::format("{}/{}", parent_dir, kLibraryPath);
 }
 
 void* LoadLibrary(const char* path) {

--- a/tests/cefclient/browser/config_test.cc
+++ b/tests/cefclient/browser/config_test.cc
@@ -5,7 +5,6 @@
 #include "tests/cefclient/browser/config_test.h"
 
 #include <map>
-#include <sstream>
 #include <string>
 #include <vector>
 

--- a/tests/cefclient/browser/preferences_test.cc
+++ b/tests/cefclient/browser/preferences_test.cc
@@ -4,7 +4,7 @@
 
 #include "tests/cefclient/browser/preferences_test.h"
 
-#include <sstream>
+#include <format>
 #include <string>
 #include <vector>
 
@@ -162,15 +162,14 @@ class Handler : public CefMessageRouterBrowserSide::Handler {
     // Create a message that accurately represents the result.
     std::string message;
     if (!changed_names.empty()) {
-      std::stringstream ss;
-      ss << "Successfully changed " << changed_names.size() << " preferences; ";
+      message = std::format("Successfully changed {} preferences; ",
+                            changed_names.size());
       for (size_t i = 0; i < changed_names.size(); ++i) {
-        ss << changed_names[i];
+        message += changed_names[i];
         if (i < changed_names.size() - 1) {
-          ss << ", ";
+          message += ", ";
         }
       }
-      message = ss.str();
     }
 
     if (!success) {

--- a/tests/cefclient/browser/response_filter_test.cc
+++ b/tests/cefclient/browser/response_filter_test.cc
@@ -5,7 +5,7 @@
 #include "tests/cefclient/browser/response_filter_test.h"
 
 #include <algorithm>
-#include <sstream>
+#include <format>
 #include <string>
 
 #include "include/base/cef_logging.h"
@@ -93,9 +93,8 @@ class FindReplaceResponseFilter : public CefResponseFilter {
         // Matched the next character in the find string.
         if (++find_match_offset_ == find_size) {
           // Complete match of the find string. Write the replace string.
-          std::stringstream ss;
-          ss << ++replace_count_ << ". " << kReplaceString;
-          const std::string& replace_str = ss.str();
+          const std::string replace_str =
+              std::format("{}. {}", ++replace_count_, kReplaceString);
           Write(replace_str.c_str(), replace_str.size(), WRITE_PARAMS);
 
           // Start over looking for a match.

--- a/tests/cefclient/browser/root_window_manager.cc
+++ b/tests/cefclient/browser/root_window_manager.cc
@@ -4,7 +4,7 @@
 
 #include "tests/cefclient/browser/root_window_manager.h"
 
-#include <sstream>
+#include <format>
 
 #include "include/base/cef_callback.h"
 #include "include/base/cef_logging.h"
@@ -369,10 +369,10 @@ CefRefPtr<CefRequestContext> RootWindowManager::CreateRequestContext(
       } else {
         // Give each browser a unique cache path. This will create completely
         // isolated context objects.
-        std::stringstream ss;
-        ss << command_line->GetSwitchValue(switches::kCachePath).ToString()
-           << file_util::kPathSep << time(nullptr);
-        CefString(&settings.cache_path) = ss.str();
+        CefString(&settings.cache_path) = std::format(
+            "{}{}{}",
+            command_line->GetSwitchValue(switches::kCachePath).ToString(),
+            file_util::kPathSep, time(nullptr));
       }
     }
 

--- a/tests/cefclient/renderer/client_renderer.cc
+++ b/tests/cefclient/renderer/client_renderer.cc
@@ -4,7 +4,6 @@
 
 #include "tests/cefclient/renderer/client_renderer.h"
 
-#include <sstream>
 #include <string>
 
 #include "include/cef_crash_util.h"

--- a/tests/cefsimple/simple_handler.cc
+++ b/tests/cefsimple/simple_handler.cc
@@ -4,7 +4,7 @@
 
 #include "tests/cefsimple/simple_handler.h"
 
-#include <sstream>
+#include <format>
 #include <string>
 
 #include "include/base/cef_callback.h"
@@ -122,13 +122,12 @@ void SimpleHandler::OnLoadError(CefRefPtr<CefBrowser> browser,
   }
 
   // Display a load error message using a data: URI.
-  std::stringstream ss;
-  ss << "<html><body bgcolor=\"white\">"
-        "<h2>Failed to load URL "
-     << std::string(failedUrl) << " with error " << std::string(errorText)
-     << " (" << errorCode << ").</h2></body></html>";
+  auto html = std::format(
+      R"html(<html><body bgcolor="white">
+<h2>Failed to load URL {} with error {} ({}).</h2></body></html>)html",
+      failedUrl.ToString(), errorText.ToString(), static_cast<int>(errorCode));
 
-  frame->LoadURL(GetDataURI(ss.str(), "text/html"));
+  frame->LoadURL(GetDataURI(html, "text/html"));
 }
 
 void SimpleHandler::ShowMainWindow() {

--- a/tests/ceftests/cookie_unittest.cc
+++ b/tests/ceftests/cookie_unittest.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <format>
 #include <vector>
 
 #include "include/base/cef_callback.h"
@@ -332,7 +333,6 @@ void TestInvalidCookie(CefRefPtr<CefCookieManager> manager,
 
 void TestMultipleCookies(CefRefPtr<CefCookieManager> manager,
                          CefRefPtr<CefWaitableEvent> event) {
-  std::stringstream ss;
   int i;
 
   CookieVector cookies;
@@ -343,12 +343,8 @@ void TestMultipleCookies(CefRefPtr<CefCookieManager> manager,
   for (i = 0; i < kNumCookies; i++) {
     CefCookie cookie;
 
-    ss << "my_cookie" << i;
-    CefString(&cookie.name).FromASCII(ss.str().c_str());
-    ss.str("");
-    ss << "My Value " << i;
-    CefString(&cookie.value).FromASCII(ss.str().c_str());
-    ss.str("");
+    CefString(&cookie.name).FromASCII(std::format("my_cookie{}", i).c_str());
+    CefString(&cookie.value).FromASCII(std::format("My Value {}", i).c_str());
 
     cookies.push_back(cookie);
   }
@@ -366,12 +362,8 @@ void TestMultipleCookies(CefRefPtr<CefCookieManager> manager,
   for (i = 0; it != cookies.end(); ++it, ++i) {
     const CefCookie& cookie = *it;
 
-    ss << "my_cookie" << i;
-    EXPECT_EQ(CefString(&cookie.name), ss.str());
-    ss.str("");
-    ss << "My Value " << i;
-    EXPECT_EQ(CefString(&cookie.value), ss.str());
-    ss.str("");
+    EXPECT_EQ(CefString(&cookie.name), std::format("my_cookie{}", i));
+    EXPECT_EQ(CefString(&cookie.value), std::format("My Value {}", i));
   }
 
   cookies.clear();
@@ -405,12 +397,8 @@ void TestMultipleCookies(CefRefPtr<CefCookieManager> manager,
   for (i = 0; i < kNumCookies; i++) {
     CefCookie cookie;
 
-    ss << "my_cookie" << i;
-    CefString(&cookie.name).FromASCII(ss.str().c_str());
-    ss.str("");
-    ss << "My Value " << i;
-    CefString(&cookie.value).FromASCII(ss.str().c_str());
-    ss.str("");
+    CefString(&cookie.name).FromASCII(std::format("my_cookie{}", i).c_str());
+    CefString(&cookie.value).FromASCII(std::format("My Value {}", i).c_str());
 
     cookies.push_back(cookie);
   }
@@ -1077,9 +1065,7 @@ std::string GetCookieAccessOrigin(const std::string& scheme,
     return test_server::GetOrigin(kUseHttpsServerScheme);
   }
 
-  std::stringstream ss;
-  ss << scheme << "://" << kCookieAccessDomain;
-  return ss.str();
+  return std::format("{}://{}", scheme, kCookieAccessDomain);
 }
 
 std::string GetCookieAccessUrl1(const std::string& scheme,

--- a/tests/ceftests/cors_unittest.cc
+++ b/tests/ceftests/cors_unittest.cc
@@ -3,8 +3,9 @@
 // can be found in the LICENSE file.
 
 #include <algorithm>
+#include <format>
 #include <set>
-#include <sstream>
+#include <string_view>
 #include <vector>
 
 #include "include/base/cef_callback.h"
@@ -69,10 +70,9 @@ std::string GetOrigin(HandlerType handler) {
       // TODO: Only call test_server::GetOrigin() after test server
       // initialization.
       if (!kUseHttpsServerScheme) {
-        std::stringstream ss;
-        ss << "http://" << test_server::kHttpServerAddress << ":"
-           << test_server::kHttpServerPort;
-        return ss.str();
+        return std::format("http://{}:{}",
+                           std::string_view(test_server::kHttpServerAddress),
+                           test_server::kHttpServerPort);
       }
       return test_server::GetOrigin(kUseHttpsServerScheme);
     case HandlerType::HTTP_SCHEME:

--- a/tests/ceftests/devtools_message_unittest.cc
+++ b/tests/ceftests/devtools_message_unittest.cc
@@ -3,7 +3,7 @@
 // can be found in the LICENSE file.
 
 #include <algorithm>
-#include <sstream>
+#include <format>
 
 #include "include/base/cef_callback.h"
 #include "include/base/cef_callback_helpers.h"
@@ -193,15 +193,16 @@ class DevToolsMessageTestHandler : public TestHandler {
 
     int message_id = next_message_id_++;
 
-    std::stringstream message;
-    message << "{\"id\":" << message_id << ",\"method\":\"" << method << "\"";
+    std::string message;
     if (!params.empty()) {
-      message << ",\"params\":" << params;
+      message = std::format(R"({{"id":{},"method":"{}","params":{}}})",
+                            message_id, method, params);
+    } else {
+      message = std::format(R"({{"id":{},"method":"{}"}})", message_id, method);
     }
-    message << "}";
 
     // Set expected result state.
-    pending_message_ = message.str();
+    pending_message_ = message;
     pending_result_next_ = std::move(next_step);
     pending_result_ = {message_id, expected_success, expected_result};
 
@@ -276,13 +277,12 @@ class DevToolsMessageTestHandler : public TestHandler {
     pending_event_next_ =
         base::BindOnce(&DevToolsMessageTestHandler::AfterNavigate, this);
 
-    std::stringstream params;
-    params << "{\"url\":\"" << kTestUrl2 << "\"}";
+    std::string params = std::format(R"({{"url":"{}"}})", kTestUrl2);
 
     // STEP 3: Page domain notifications are enabled. Now start a new
     // navigation (but do nothing on method result) and wait for the
     // "Page.frameNavigated" event.
-    ExecuteMethod("Page.navigate", params.str(), base::DoNothing(),
+    ExecuteMethod("Page.navigate", params, base::DoNothing(),
                   /*expected_result=*/"{\"frameId\":");
   }
 

--- a/tests/ceftests/dom_unittest.cc
+++ b/tests/ceftests/dom_unittest.cc
@@ -2,6 +2,8 @@
 // reserved. Use of this source code is governed by a BSD-style license that
 // can be found in the LICENSE file.
 
+#include <string>
+
 #include "include/cef_dom.h"
 #include "tests/ceftests/test_handler.h"
 #include "tests/gtest/include/gtest/gtest.h"
@@ -293,18 +295,18 @@ class TestDOMHandler : public TestHandler {
 
   void RunTest() override {
     // Specified values are in CSS pixels.
-    std::stringstream mainHtml;
-    mainHtml << "<html>"
-                "<head><title>The Title</title></head>"
-                "<body>"
-                "<h1>Hello From<br class=\"some_class\"/ id=\"some_id\"/>"
-                "Main Frame</h1>"
-                "<div id=\"sized_element\" style=\"width: 50px; height: 25px; "
-                "position: fixed; top: 100px; left: 150px;\"/>"
-                "</body>"
-                "</html>";
+    std::string mainHtml =
+        "<html>"
+        "<head><title>The Title</title></head>"
+        "<body>"
+        "<h1>Hello From<br class=\"some_class\"/ id=\"some_id\"/>"
+        "Main Frame</h1>"
+        "<div id=\"sized_element\" style=\"width: 50px; height: 25px; "
+        "position: fixed; top: 100px; left: 150px;\"/>"
+        "</body>"
+        "</html>";
 
-    AddResource(kTestUrl, mainHtml.str(), "text/html");
+    AddResource(kTestUrl, mainHtml, "text/html");
     CreateBrowser(kTestUrl);
 
     // Time out the test after a reasonable period of time.

--- a/tests/ceftests/frame_handler_unittest.cc
+++ b/tests/ceftests/frame_handler_unittest.cc
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
+#include <format>
 #include <limits>
 #include <map>
 #include <memory>
 #include <queue>
 #include <set>
-#include <sstream>
 #include <string>
 
 #include "include/base/cef_callback.h"
@@ -104,10 +104,8 @@ struct FrameStatus {
     const int expected_ct = is_temporary_ ? 0 : expected_query_ct_;
 #if VERBOSE_DEBUGGING
     if (msg) {
-      std::stringstream ss;
-      ss << ident_str_ << "(expected=" << expected_ct
-         << " delivered=" << delivered_query_ct_ << ")";
-      *msg += ss.str();
+      *msg += std::format("{}(expected={} delivered={})", ident_str_,
+                          expected_ct, delivered_query_ct_);
     }
 #endif
     return delivered_query_ct_ == expected_ct;
@@ -124,16 +122,15 @@ struct FrameStatus {
   bool IsLoaded(std::string* msg = nullptr) const {
 #if VERBOSE_DEBUGGING
     if (msg) {
-      std::stringstream ss;
-      ss << ident_str_ << "(";
+      *msg += ident_str_ + "(";
       for (int i = 0; i <= LOAD_END; ++i) {
-        ss << GetCallbackName(i) << "=" << got_callback_[i];
+        *msg += std::format("{}={}", GetCallbackName(i),
+                            static_cast<bool>(got_callback_[i]));
         if (i < LOAD_END) {
-          ss << " ";
+          *msg += " ";
         }
       }
-      ss << ")";
-      *msg += ss.str();
+      *msg += ")";
     }
 #endif
     return got_callback_[LOAD_END];
@@ -165,11 +162,10 @@ struct FrameStatus {
   std::string GetDebugString(bool dump_state = false) const {
     std::string result = debug_info_ + ident_str_;
     if (dump_state) {
-      std::stringstream ss;
-      ss << "\nis_main=" << is_main_ << "\nis_first_main=" << is_first_main_
-         << "\nis_last_main=" << is_last_main_
-         << "\nis_temporary=" << is_temporary_;
-      result += ss.str();
+      result += std::format(
+          "\nis_main={}\nis_first_main={}\nis_last_main={}"
+          "\nis_temporary={}",
+          is_main_, is_first_main_, is_last_main_, is_temporary_);
     }
     return result;
   }
@@ -913,14 +909,13 @@ class NavigateOrderMainTestHandler : public OrderMainTestHandler {
   }
 
   std::string GetURLForNav(int nav, const std::string& suffix = "") const {
-    std::stringstream ss;
     if (cross_origin_) {
-      ss << kOrderMainUrlPrefix << nav << "/cross-origin" << suffix << ".html";
+      return std::format("{}{}/cross-origin{}.html", kOrderMainUrlPrefix, nav,
+                         suffix);
     } else {
-      ss << kOrderMainUrlPrefix << "/" << nav << "same-origin" << suffix
-         << ".html";
+      return std::format("{}/{}same-origin{}.html", kOrderMainUrlPrefix, nav,
+                         suffix);
     }
-    return ss.str();
   }
 
  private:
@@ -1003,10 +998,8 @@ class FrameStatusMap {
     if (size() != expected_frame_ct_) {
 #if VERBOSE_DEBUGGING
       if (msg) {
-        std::stringstream ss;
-        ss << " SUB COUNT MISMATCH! size=" << size()
-           << " expected=" << expected_frame_ct_;
-        *msg += ss.str();
+        *msg += std::format(" SUB COUNT MISMATCH! size={} expected={}", size(),
+                            expected_frame_ct_);
       }
 #endif
       return false;
@@ -1031,10 +1024,8 @@ class FrameStatusMap {
     if (size() != expected_frame_ct_) {
 #if VERBOSE_DEBUGGING
       if (msg) {
-        std::stringstream ss;
-        ss << " SUB COUNT MISMATCH! size=" << size()
-           << " expected=" << expected_frame_ct_;
-        *msg += ss.str();
+        *msg += std::format(" SUB COUNT MISMATCH! size={} expected={}", size(),
+                            expected_frame_ct_);
       }
 #endif
       return false;
@@ -1497,15 +1488,13 @@ class CrossOriginOrderSubTestHandler : public OrderSubTestHandler {
 
  protected:
   std::string GetSubURL1ForNav(int nav) const override {
-    std::stringstream ss;
-    ss << kOrderMainUrlPrefix << nav << "-sub1/sub-cross-origin.html";
-    return ss.str();
+    return std::format("{}{}-sub1/sub-cross-origin.html", kOrderMainUrlPrefix,
+                       nav);
   }
 
   std::string GetSubURL2ForNav(int nav) const override {
-    std::stringstream ss;
-    ss << kOrderMainUrlPrefix << nav << "-sub2/sub-cross-origin.html";
-    return ss.str();
+    return std::format("{}{}-sub2/sub-cross-origin.html", kOrderMainUrlPrefix,
+                       nav);
   }
 
   void VerifyTestResults() override {

--- a/tests/ceftests/frame_unittest.cc
+++ b/tests/ceftests/frame_unittest.cc
@@ -2,6 +2,7 @@
 // reserved. Use of this source code is governed by a BSD-style license that
 // can be found in the LICENSE file.
 
+#include <format>
 #include <memory>
 
 #include "include/base/cef_callback.h"
@@ -1146,9 +1147,7 @@ class FrameNavExpectationsRendererMultiNav
 
 // Create a URL containing the nav number.
 std::string GetMultiNavURL(const std::string& origin, int nav) {
-  std::stringstream ss;
-  ss << origin << "nav" << nav << ".html";
-  return ss.str();
+  return std::format("{}nav{}.html", origin, nav);
 }
 
 // Extract the nav number from the URL.
@@ -1829,18 +1828,16 @@ class FrameNavExpectationsBrowserTestNestedIframes
         return "<html><body>Nav2<iframe src=\"" + GetMultiNavURL(origin_, 2) +
                "\"></body></html>";
       case 2: {
-        // Frame 2. Contains an named iframe created via javascript.
-        std::stringstream ss;
-        // clang-format off
-        ss << "<html><script>"
-           << "  function createFrame() {"
-           << "    var f = document.createElement('iframe');"
-           << "    f.name = 'nav3';"
-           << "    f.src = '" << GetMultiNavURL(origin_, 3) << "';"
-           << "    document.body.appendChild(f);"
-           << "  }</script><body onload=\"createFrame()\">Nav3</body></html>";
-        // clang-format on
-        return ss.str();
+        // Frame 2. Contains a named iframe created via javascript.
+        return std::format(
+            R"html(<html><script>
+  function createFrame() {{
+    var f = document.createElement('iframe');
+    f.name = 'nav3';
+    f.src = '{}';
+    document.body.appendChild(f);
+  }}</script><body onload="createFrame()">Nav3</body></html>)html",
+            GetMultiNavURL(origin_, 3));
       }
       case 3:
         // Frame 3.

--- a/tests/ceftests/message_router_multi_query_unittest.cc
+++ b/tests/ceftests/message_router_multi_query_unittest.cc
@@ -830,11 +830,7 @@ class MultiQueryManager {
     return SplitIDString(result, value, index);
   }
 
-  std::string GetIntString(int val) const {
-    std::stringstream ss;
-    ss << val;
-    return ss.str();
-  }
+  std::string GetIntString(int val) const { return std::to_string(val); }
 
   int GetIDFromIndex(int index) const { return id_offset_ + index; }
   int GetIndexFromID(int id) const { return id - id_offset_; }
@@ -1250,9 +1246,7 @@ class MultiQueryMultiHandlerTestHandler : public SingleLoadTestHandler,
 
    private:
     static std::string HandledRequest(int index) {
-      std::stringstream ss;
-      ss << kMultiQueryRequest << ":" << index;
-      return ss.str();
+      return std::string(kMultiQueryRequest) + ":" + std::to_string(index);
     }
 
     MultiQueryMultiHandlerTestHandler* test_handler_;

--- a/tests/ceftests/message_router_single_query_unittest.cc
+++ b/tests/ceftests/message_router_single_query_unittest.cc
@@ -26,9 +26,7 @@ class SingleQueryTestHandler : public SingleLoadTestHandler {
   std::string GetMainHTML() override {
     std::string html;
 
-    std::stringstream ss;
-    ss << kSingleQueryErrorCode;
-    const std::string& errorCodeStr = ss.str();
+    const std::string errorCodeStr = std::to_string(kSingleQueryErrorCode);
 
     html =
         "<html><body><script>\n"
@@ -278,12 +276,9 @@ class SinglePersistentQueryTestHandler : public SingleLoadTestHandler {
   std::string GetMainHTML() override {
     std::string html;
 
-    std::stringstream ss;
-    ss << kSinglePersistentQueryResponseCount;
-    const std::string& responseCountStr = ss.str();
-    ss.str("");
-    ss << kSingleQueryErrorCode;
-    const std::string& errorCodeStr = ss.str();
+    const std::string responseCountStr =
+        std::to_string(kSinglePersistentQueryResponseCount);
+    const std::string errorCodeStr = std::to_string(kSingleQueryErrorCode);
 
     html =
         "<html><body><script>\n"

--- a/tests/ceftests/message_router_unittest_utils.cc
+++ b/tests/ceftests/message_router_unittest_utils.cc
@@ -4,6 +4,8 @@
 
 #include "tests/ceftests/message_router_unittest_utils.h"
 
+#include <format>
+
 extern const char kJSQueryFunc[] = "mrtQuery";
 extern const char kJSQueryCancelFunc[] = "mrtQueryCancel";
 
@@ -74,10 +76,9 @@ bool MRRenderDelegate::V8HandlerImpl::Execute(const CefString& name,
     }
 
     if (expected_count != actual_count) {
-      std::stringstream ss;
-      ss << message_name << " failed (line " << line_no << "); expected "
-         << expected_count << ", got " << actual_count;
-      exception = ss.str();
+      exception =
+          std::format("{} failed (line {}); expected {}, got {}", message_name,
+                      line_no, expected_count, actual_count);
     }
   }
 

--- a/tests/ceftests/navigation_unittest.cc
+++ b/tests/ceftests/navigation_unittest.cc
@@ -3,6 +3,7 @@
 // can be found in the LICENSE file.
 
 #include <algorithm>
+#include <format>
 #include <list>
 
 #include "include/base/cef_callback.h"
@@ -2257,9 +2258,7 @@ class PopupSimultaneousTestHandler : public TestHandler {
       if (same_url_) {
         popup_url_[i] = std::string(kSimultPopupPopupUrl) + ".html";
       } else {
-        std::stringstream ss;
-        ss << kSimultPopupPopupUrl << i << ".html";
-        popup_url_[i] = ss.str();
+        popup_url_[i] = std::format("{}{}.html", kSimultPopupPopupUrl, i);
       }
       main_html += "window.open('" + popup_url_[i] + "');\n";
       AddResource(popup_url_[i], "<html>Popup " + popup_url_[i] + "</html>",

--- a/tests/ceftests/request_handler_unittest.cc
+++ b/tests/ceftests/request_handler_unittest.cc
@@ -4,8 +4,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <format>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -48,13 +48,11 @@ class NetNotifyTestHandler : public TestHandler {
         same_origin_(same_origin) {}
 
   void SetupTest() override {
-    std::stringstream ss;
-    ss << kNetNotifyOrigin1 << "nav1.html?t=" << test_type_;
-    url1_ = ss.str();
-    ss.str("");
-    ss << (same_origin_ ? kNetNotifyOrigin1 : kNetNotifyOrigin2)
-       << "nav2.html?t=" << test_type_;
-    url2_ = ss.str();
+    url1_ = std::format("{}nav1.html?t={}", kNetNotifyOrigin1,
+                        static_cast<int>(test_type_));
+    url2_ = std::format("{}nav2.html?t={}",
+                        same_origin_ ? kNetNotifyOrigin1 : kNetNotifyOrigin2,
+                        static_cast<int>(test_type_));
 
     const std::string& resource1 =
         "<html>"

--- a/tests/ceftests/resource_manager_unittest.cc
+++ b/tests/ceftests/resource_manager_unittest.cc
@@ -2,6 +2,7 @@
 // reserved. Use of this source code is governed by a BSD-style license that
 // can be found in the LICENSE file.
 
+#include <format>
 #include <memory>
 #include <vector>
 
@@ -1049,15 +1050,13 @@ TEST(ResourceManagerTest, ManyRequests) {
   state.expected_message_ct_ = 50U;
 
   // Build a page with lots of iframes.
-  std::stringstream ss;
-  ss << "<html><body>";
+  std::string html = "<html><body>";
   for (size_t i = 0U; i < state.expected_message_ct_; ++i) {
-    ss << "<iframe src=\"" << kBaseUrl << (i * 10) << "\"></iframe>";
+    html += std::format(R"(<iframe src="{}{}"></iframe>)", kBaseUrl, i * 10);
   }
-  ss << "</body></html>";
+  html += "</body></html>";
 
-  state.manager_->AddContentProvider(kUrl, ss.str(), "text/html", 0,
-                                     std::string());
+  state.manager_->AddContentProvider(kUrl, html, "text/html", 0, std::string());
   state.manager_->AddProvider(new EchoProvider(kBaseUrl), 0, std::string());
 
   CefRefPtr<ResourceManagerTestHandler> handler =
@@ -1075,9 +1074,7 @@ TEST(ResourceManagerTest, ManyRequests) {
 
   // Requests should complete in order due to the delay.
   for (size_t i = 0; i < state.messages_.size(); ++i) {
-    ss.str("");
-    ss << kBaseUrl << (i * 10);
-    EXPECT_EQ(ss.str(), state.messages_[i]);
+    EXPECT_EQ(std::format("{}{}", kBaseUrl, i * 10), state.messages_[i]);
   }
 }
 

--- a/tests/ceftests/resource_request_handler_unittest.cc
+++ b/tests/ceftests/resource_request_handler_unittest.cc
@@ -4,8 +4,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <format>
 #include <memory>
-#include <sstream>
 #include <string>
 
 #include "include/base/cef_callback.h"
@@ -2219,33 +2219,26 @@ class SubresourceResponseTest : public RoutingTestHandler {
   }
 
   std::string GetMainResponseBody() const {
-    std::stringstream html;
-    html << "<html><head>";
-
+    std::string content;
     if (subframe_) {
       const std::string& url = GetSubURL();
-      html << "<iframe src=\"" << url << "\"></iframe>";
+      content = std::format(R"(<iframe src="{}"></iframe>)", url);
     } else {
       const std::string& url = GetStartupURL();
-      html << "<script type=\"text/javascript\" src=\"" << url
-           << "\"></script>";
+      content = std::format(
+          R"(<script type="text/javascript" src="{}"></script>)", url);
     }
-
-    html << "</head><body><p>Main</p></body></html>";
-    return html.str();
+    return std::format("<html><head>{}</head><body><p>Main</p></body></html>",
+                       content);
   }
 
   std::string GetSubResponseBody() const {
     EXPECT_TRUE(subframe_);
 
-    std::stringstream html;
-    html << "<html><head>";
-
     const std::string& url = GetStartupURL();
-    html << "<script type=\"text/javascript\" src=\"" << url << "\"></script>";
-
-    html << "</head><body><p>Sub</p></body></html>";
-    return html.str();
+    return std::format(
+        R"(<html><head><script type="text/javascript" src="{}"></script></head><body><p>Sub</p></body></html>)",
+        url);
   }
 
   std::string GetResponseBody() const {
@@ -2776,14 +2769,10 @@ class RedirectResponseTest : public TestHandler {
 
  private:
   std::string GetHtml() const {
-    std::stringstream html;
-    html << "<html><head>";
-
     const std::string& url = resource_test_->start_url();
-    html << "<script type=\"text/javascript\" src=\"" << url << "\"></script>";
-
-    html << "</head><body><p>Main</p></body></html>";
-    return html.str();
+    return std::format(
+        R"(<html><head><script type="text/javascript" src="{}"></script></head><body><p>Main</p></body></html>)",
+        url);
   }
 
   class ResourceTest {

--- a/tests/ceftests/server_unittest.cc
+++ b/tests/ceftests/server_unittest.cc
@@ -2,11 +2,11 @@
 // reserved. Use of this source code is governed by a BSD-style license that
 // can be found in the LICENSE file.
 
+#include <format>
 #include <list>
 #include <map>
 #include <memory>
 #include <set>
-#include <sstream>
 
 #include "include/base/cef_callback.h"
 #include "include/base/cef_ref_counted.h"
@@ -27,10 +27,8 @@ const uint16_t kTestServerPort = 8099;
 const int kTestTimeout = 5000;
 
 std::string GetTestServerOrigin(bool is_websocket) {
-  std::stringstream ss;
-  ss << (is_websocket ? "ws://" : "http://") << kTestServerAddress << ":"
-     << kTestServerPort;
-  return ss.str();
+  return std::format("{}://{}:{}", is_websocket ? "ws" : "http",
+                     kTestServerAddress, kTestServerPort);
 }
 
 // Handles the test server. Used for both HTTP and WebSocket tests.
@@ -1334,12 +1332,8 @@ class EchoWebSocketTestHandler : public WebSocketTestHandler {
         in_parallel_(in_parallel) {}
 
   std::string GetClientHtml() override {
-    std::stringstream ss;
-    ss << connection_ct_;
-    std::string cct_str = ss.str();
-    ss.str("");
-    ss << message_ct_;
-    std::string mct_str = ss.str();
+    std::string cct_str = std::to_string(connection_ct_);
+    std::string mct_str = std::to_string(message_ct_);
 
     // clang-format off
     return

--- a/tests/ceftests/test_handler.cc
+++ b/tests/ceftests/test_handler.cc
@@ -4,8 +4,8 @@
 
 #include "tests/ceftests/test_handler.h"
 
+#include <format>
 #include <memory>
-#include <sstream>
 
 #include "include/base/cef_callback.h"
 #include "include/base/cef_logging.h"
@@ -440,9 +440,7 @@ void TestHandler::OnClosed(int browser_id, NotifyType type) {
 
 std::string TestHandler::MakeDebugStringPrefix() const {
 #if VERBOSE_DEBUGGING
-  std::stringstream ss;
-  ss << "TestHandler [0x" << std::hex << this << "]: ";
-  return ss.str();
+  return std::format("TestHandler [{}]: ", static_cast<const void*>(this));
 #else
   return std::string();
 #endif

--- a/tests/ceftests/test_server_observer_unittest.cc
+++ b/tests/ceftests/test_server_observer_unittest.cc
@@ -4,7 +4,7 @@
 
 #include "tests/ceftests/test_server_observer.h"
 
-#include <sstream>
+#include <format>
 
 #include "include/cef_command_line.h"
 #include "include/cef_task.h"
@@ -198,12 +198,12 @@ void RunHelperMultiple(bool https_server) {
   const size_t size = std::size(states);
 
   for (size_t i = 0; i < size; ++i) {
-    std::stringstream ss;
-    ss << "/TestServerTest.ObserverHelperMultiple" << i;
     auto done_callback =
         base::BindOnce(SignalIfDone, event, base::Unretained(&count), size);
     states[i].https_server = https_server;
-    CreateObserverOnUIThread(&states[i], ss.str(), std::move(done_callback));
+    CreateObserverOnUIThread(
+        &states[i], std::format("/TestServerTest.ObserverHelperMultiple{}", i),
+        std::move(done_callback));
   }
 
   Wait(event);

--- a/tests/ceftests/urlrequest_unittest.cc
+++ b/tests/ceftests/urlrequest_unittest.cc
@@ -3,9 +3,9 @@
 // can be found in the LICENSE file.
 
 #include <algorithm>
+#include <format>
 #include <map>
 #include <memory>
-#include <sstream>
 #include <vector>
 
 #include "include/base/cef_callback.h"
@@ -345,9 +345,7 @@ std::string GetRequestScheme(bool server_backend) {
 std::string GetRequestHost(bool server_backend, bool with_port) {
   if (server_backend) {
     if (with_port) {
-      std::stringstream ss;
-      ss << kRequestAddressServer << ":" << kRequestPortServer;
-      return ss.str();
+      return std::format("{}:{}", kRequestAddressServer, kRequestPortServer);
     } else {
       return kRequestAddressServer;
     }
@@ -542,9 +540,9 @@ void GetNormalResponse(const RequestRunSettings* settings,
   settings->response->GetHeaderMap(headerMap);
 
   if (settings->expect_save_cookie) {
-    std::stringstream ss;
-    ss << kRequestSaveCookieName << "=" << "save-cookie-value";
-    headerMap.insert(std::make_pair("Set-Cookie", ss.str()));
+    headerMap.insert(std::make_pair(
+        "Set-Cookie",
+        std::format("{}=save-cookie-value", kRequestSaveCookieName)));
   }
 
   response->SetHeaderMap(headerMap);

--- a/tests/ceftests/v8_unittest.cc
+++ b/tests/ceftests/v8_unittest.cc
@@ -2,7 +2,9 @@
 // reserved. Use of this source code is governed by a BSD-style license that
 // can be found in the LICENSE file.
 
-#include <sstream>
+#include <format>
+#include <iterator>
+#include <string>
 
 #include "include/base/cef_callback.h"
 #include "include/cef_task.h"
@@ -1777,14 +1779,14 @@ class V8RendererTest : public ClientAppRenderer::Delegate,
     object->SetValue(kName, CefV8Value::CreateInt(kVal1),
                      V8_PROPERTY_ATTRIBUTE_NONE);
 
-    std::stringstream test;
-    test << "if (window." << kName << " != " << kVal1 << ") throw 'Fail';\n"
-         << "window." << kName << " = " << kVal2 << ";";
+    std::string test =
+        std::format("if (window.{} != {}) throw 'Fail';\nwindow.{} = {};",
+                    kName, kVal1, kName, kVal2);
 
     CefRefPtr<CefV8Value> retval;
     CefRefPtr<CefV8Exception> exception;
 
-    EXPECT_TRUE(context->Eval(test.str(), CefString(), 0, retval, exception));
+    EXPECT_TRUE(context->Eval(test, CefString(), 0, retval, exception));
     if (exception.get()) {
       ADD_FAILURE() << exception->GetMessage().c_str();
     }
@@ -1816,14 +1818,14 @@ class V8RendererTest : public ClientAppRenderer::Delegate,
     object->SetValue(kName, CefV8Value::CreateInt(kVal1),
                      V8_PROPERTY_ATTRIBUTE_READONLY);
 
-    std::stringstream test;
-    test << "if (window." << kName << " != " << kVal1 << ") throw 'Fail';\n"
-         << "window." << kName << " = " << kVal2 << ";";
+    std::string test =
+        std::format("if (window.{} != {}) throw 'Fail';\nwindow.{} = {};",
+                    kName, kVal1, kName, kVal2);
 
     CefRefPtr<CefV8Value> retval;
     CefRefPtr<CefV8Exception> exception;
 
-    EXPECT_TRUE(context->Eval(test.str(), CefString(), 0, retval, exception));
+    EXPECT_TRUE(context->Eval(test, CefString(), 0, retval, exception));
     if (exception.get()) {
       ADD_FAILURE() << exception->GetMessage().c_str();
     }
@@ -1857,18 +1859,13 @@ class V8RendererTest : public ClientAppRenderer::Delegate,
     obj1->SetValue(kArgName, CefV8Value::CreateInt(0),
                    V8_PROPERTY_ATTRIBUTE_NONE);
 
-    std::stringstream test;
-    test << "for (var i in window." << kObjName
-         << ") {\n"
-            "window."
-         << kObjName
-         << "[i]++;\n"
-            "}";
+    std::string test = std::format(
+        "for (var i in window.{}) {{\nwindow.{}[i]++;\n}}", kObjName, kObjName);
 
     CefRefPtr<CefV8Value> retval;
     CefRefPtr<CefV8Exception> exception;
 
-    EXPECT_TRUE(context->Eval(test.str(), CefString(), 0, retval, exception));
+    EXPECT_TRUE(context->Eval(test, CefString(), 0, retval, exception));
     if (exception.get()) {
       ADD_FAILURE() << exception->GetMessage().c_str();
     }
@@ -1902,18 +1899,13 @@ class V8RendererTest : public ClientAppRenderer::Delegate,
     obj1->SetValue(kArgName, CefV8Value::CreateInt(0),
                    V8_PROPERTY_ATTRIBUTE_DONTENUM);
 
-    std::stringstream test;
-    test << "for (var i in window." << kObjName
-         << ") {\n"
-            "window."
-         << kObjName
-         << "[i]++;\n"
-            "}";
+    std::string test = std::format(
+        "for (var i in window.{}) {{\nwindow.{}[i]++;\n}}", kObjName, kObjName);
 
     CefRefPtr<CefV8Value> retval;
     CefRefPtr<CefV8Exception> exception;
 
-    EXPECT_TRUE(context->Eval(test.str(), CefString(), 0, retval, exception));
+    EXPECT_TRUE(context->Eval(test, CefString(), 0, retval, exception));
     if (exception.get()) {
       ADD_FAILURE() << exception->GetMessage().c_str();
     }
@@ -1945,17 +1937,15 @@ class V8RendererTest : public ClientAppRenderer::Delegate,
     object->SetValue(kName, CefV8Value::CreateInt(kVal1),
                      V8_PROPERTY_ATTRIBUTE_NONE);
 
-    std::stringstream test;
-    test << "if (window." << kName << " != " << kVal1 << ") throw 'Fail';\n"
-         << "window." << kName << " = " << kVal2
-         << ";\n"
-            "delete window."
-         << kName << ";";
+    std::string test = std::format(
+        "if (window.{} != {}) throw 'Fail';\nwindow.{} = {};\ndelete "
+        "window.{};",
+        kName, kVal1, kName, kVal2, kName);
 
     CefRefPtr<CefV8Value> retval;
     CefRefPtr<CefV8Exception> exception;
 
-    EXPECT_TRUE(context->Eval(test.str(), CefString(), 0, retval, exception));
+    EXPECT_TRUE(context->Eval(test, CefString(), 0, retval, exception));
     if (exception.get()) {
       ADD_FAILURE() << exception->GetMessage().c_str();
     }
@@ -1987,17 +1977,15 @@ class V8RendererTest : public ClientAppRenderer::Delegate,
     object->SetValue(kName, CefV8Value::CreateInt(kVal1),
                      V8_PROPERTY_ATTRIBUTE_DONTDELETE);
 
-    std::stringstream test;
-    test << "if (window." << kName << " != " << kVal1 << ") throw 'Fail';\n"
-         << "window." << kName << " = " << kVal2
-         << ";\n"
-            "delete window."
-         << kName << ";";
+    std::string test = std::format(
+        "if (window.{} != {}) throw 'Fail';\nwindow.{} = {};\ndelete "
+        "window.{};",
+        kName, kVal1, kName, kVal2, kName);
 
     CefRefPtr<CefV8Value> retval;
     CefRefPtr<CefV8Exception> exception;
 
-    EXPECT_TRUE(context->Eval(test.str(), CefString(), 0, retval, exception));
+    EXPECT_TRUE(context->Eval(test, CefString(), 0, retval, exception));
     if (exception.get()) {
       ADD_FAILURE() << exception->GetMessage().c_str();
     }
@@ -2535,11 +2523,10 @@ class V8RendererTest : public ClientAppRenderer::Delegate,
     CefRefPtr<CefV8Value> retval;
     CefRefPtr<CefV8Exception> exception;
 
-    std::stringstream test;
-    test << "window." << kPromiseName << ".then(" << kResolveName << ").catch("
-         << kRejectName << ")";
+    std::string test = std::format("window.{}.then({}).catch({})", kPromiseName,
+                                   kResolveName, kRejectName);
 
-    EXPECT_TRUE(context->Eval(test.str(), CefString(), 0, retval, exception));
+    EXPECT_TRUE(context->Eval(test, CefString(), 0, retval, exception));
     EXPECT_TRUE(retval.get());
     EXPECT_TRUE(retval->IsPromise());
     EXPECT_FALSE(exception.get());
@@ -2632,11 +2619,10 @@ class V8RendererTest : public ClientAppRenderer::Delegate,
     CefRefPtr<CefV8Value> retval;
     CefRefPtr<CefV8Exception> exception;
 
-    std::stringstream test;
-    test << "window." << kPromiseName << ".then(" << kResolveName << ").catch("
-         << kRejectName << ")";
+    std::string test = std::format("window.{}.then({}).catch({})", kPromiseName,
+                                   kResolveName, kRejectName);
 
-    EXPECT_TRUE(context->Eval(test.str(), CefString(), 0, retval, exception));
+    EXPECT_TRUE(context->Eval(test, CefString(), 0, retval, exception));
     EXPECT_TRUE(retval.get());
     EXPECT_TRUE(retval->IsPromise());
     EXPECT_FALSE(exception.get());
@@ -3092,19 +3078,18 @@ class V8RendererTest : public ClientAppRenderer::Delegate,
       EXPECT_TRUE(test_context_->IsSame(context));
       EXPECT_STREQ("Uncaught ReferenceError: asd is not defined",
                    exception->GetMessage().ToString().c_str());
-      std::ostringstream stackFormatted;
+      std::string stackFormatted;
       for (int i = 0; i < stackTrace->GetFrameCount(); ++i) {
-        stackFormatted << "at "
-                       << stackTrace->GetFrame(i)->GetFunctionName().ToString()
-                       << "() in "
-                       << stackTrace->GetFrame(i)->GetScriptName().ToString()
-                       << " on line "
-                       << stackTrace->GetFrame(i)->GetLineNumber() << "\n";
+        stackFormatted +=
+            std::format("at {}() in {} on line {}\n",
+                        stackTrace->GetFrame(i)->GetFunctionName().ToString(),
+                        stackTrace->GetFrame(i)->GetScriptName().ToString(),
+                        stackTrace->GetFrame(i)->GetLineNumber());
       }
       const char* stackFormattedShouldBe =
           "at test2() in https://tests/V8Test.OnUncaughtException on line 3\n"
           "at test() in https://tests/V8Test.OnUncaughtException on line 2\n";
-      EXPECT_STREQ(stackFormattedShouldBe, stackFormatted.str().c_str());
+      EXPECT_STREQ(stackFormattedShouldBe, stackFormatted.c_str());
       DestroyTest();
     }
   }


### PR DESCRIPTION
Replace std::stringstream usage with std::format for string formatting throughout the CEF codebase. This improves code readability and leverages C++20's type-safe, compile-time validated formatting.

Also removes unused <sstream> includes and replaces stream accumulator patterns with more efficient std::string += operations where appropriate.