### PR TITLE
views: fix crashes due dangling pointers

### DIFF
--- a/include/views/cef_view_delegate.h
+++ b/include/views/cef_view_delegate.h
@@ -152,6 +152,17 @@ class CefViewDelegate : public virtual CefBaseRefCounted {
   ///
   /*--cef()--*/
   virtual void OnThemeChanged(CefRefPtr<CefView> view) {}
+
+#if CEF_API_ADDED(CEF_NEXT)
+  ///
+  /// Called by CefBrowserPlatformDelegateChromeViews::BrowserDestroyed()
+  ///
+  /// We have to drop our reference to the native delegate, because it's
+  /// going to be destroyed very soon.
+  ///
+  /*--cef(added=next)--*/
+  virtual void ClearNativeDelegate() {}
+#endif
 };
 
 #endif  // CEF_INCLUDE_VIEWS_CEF_WINDOW_DELEGATE_H_

--- a/libcef/browser/chrome/views/browser_platform_delegate_chrome_views.cc
+++ b/libcef/browser/chrome/views/browser_platform_delegate_chrome_views.cc
@@ -92,6 +92,12 @@ void CefBrowserPlatformDelegateChromeViews::BrowserDestroyed(
   CefBrowserPlatformDelegateChrome::BrowserDestroyed(browser);
   // |browser_view_| may be destroyed before this callback arrives.
   if (browser_view_) {
+    CefRefPtr<CefWindow> window = browser_view_->GetWindow();
+    if (window) {
+      CefRefPtr<CefViewDelegate> delegate = window->GetDelegate();
+      if (delegate)
+        delegate->ClearNativeDelegate();
+    }
     browser_view_->BrowserDestroyed(browser);
   }
   browser_view_ = nullptr;

--- a/libcef/browser/chrome/views/chrome_child_window.cc
+++ b/libcef/browser/chrome/views/chrome_child_window.cc
@@ -70,6 +70,12 @@ class ChildWindowDelegate : public CefWindowDelegate {
 #endif
   }
 
+  void ClearNativeDelegate() override {
+#if defined(USE_AURA)
+    native_delegate_ = nullptr;
+#endif
+  }
+
   CefRect GetInitialBounds(CefRefPtr<CefWindow> window) override {
     CefRect initial_bounds(window_info_.bounds);
     if (initial_bounds.IsEmpty()) {

--- a/libcef/browser/chrome/views/chrome_child_window.cc
+++ b/libcef/browser/chrome/views/chrome_child_window.cc
@@ -65,9 +65,7 @@ class ChildWindowDelegate : public CefWindowDelegate {
   void OnWindowDestroyed(CefRefPtr<CefWindow> window) override {
     browser_view_ = nullptr;
     window_ = nullptr;
-#if BUILDFLAG(IS_WIN)
     native_delegate_ = nullptr;
-#endif
   }
 
   void ClearNativeDelegate() override {


### PR DESCRIPTION
 1. views: callback for clearing native_delegate_

    When closing the browser, the native_delegate back reference might still
    point to the CefBrowserPlatformDelegateNativeAura object, while it's
    already been destroyed (via UserData destruction), leading the dangling
    pointer detection to crash the browser.

    Calling from CefBrowserPlatformDelegateChromeViews::BrowserDestroyed()
    back into the view delegate in order to clear that reference.

2. views: ChildWindowDelegate: clear native_delegate_ on destruct

    Make sure we don't have any dangling pointers to already destroyed objects.
    Even if they aren't actually accessed anymore, that's still causing the
    reference checker to panic (thus crashing the application).
