### PR TITLE
.gitignore.in: ignore python bytecode cache

### DIFF
--- a/.gitignore.in
+++ b/.gitignore.in
@@ -57,3 +57,4 @@ Thumbs.db
 /tools/claude/build_output.txt
 /tools/claude/patch_analysis.txt
 /tools/claude/patch_output.txt
+__pycache__


### PR DESCRIPTION
Don't risk those temporary files being committed accidentially.