### PR TITLE
Update to Chromium version 146.0.7680.16

### DIFF
--- a/CHROMIUM_BUILD_COMPATIBILITY.txt
+++ b/CHROMIUM_BUILD_COMPATIBILITY.txt
@@ -7,5 +7,5 @@
 # https://chromiumembedded.github.io/cef/branches_and_building
 
 {
-  'chromium_checkout': 'refs/tags/146.0.7680.14'
+  'chromium_checkout': 'refs/tags/146.0.7680.16'
 }

--- a/patch/patches/chrome_browser_browser.patch
+++ b/patch/patches/chrome_browser_browser.patch
@@ -815,7 +815,7 @@ index 8fcba62fa159924eaa33f5c9f1b57dc8ab5db863..25b96e03a9e2598a6c5a6dbf0ad60bf7
    }
  
 diff --git chrome/browser/ui/browser_window/internal/browser_window_features.cc chrome/browser/ui/browser_window/internal/browser_window_features.cc
-index 1333104aa9d3b85ee8df7e4406c2deabd2c1c931..ebfe8d154ad8a891ea8564564824b0e10203c8f8 100644
+index 7421f3a3323063f0aa9f703bd2889112aeadb379..b3caf4340e765831295c9eebbb75ab50ce00a738 100644
 --- chrome/browser/ui/browser_window/internal/browser_window_features.cc
 +++ chrome/browser/ui/browser_window/internal/browser_window_features.cc
 @@ -215,6 +215,15 @@ class BrowserWindowFeatures::ExtensionKeybindingRegistryDelegateTabStrip final

--- a/patch/patches/component_updater_4087.patch
+++ b/patch/patches/component_updater_4087.patch
@@ -5,16 +5,16 @@ index d8d54fa1b2475717cdb793f63012530fc43ed663..05312ee4215d49fe3d548d4c847b964a
 @@ -19,6 +19,7 @@
  #include "build/build_config.h"
  #include "components/update_client/update_client.h"
-
+ 
 +class CefComponentUpdaterImpl;
  class ComponentsHandler;
  class PluginObserver;
-
+ 
 @@ -235,6 +236,7 @@ class OnDemandUpdater {
    friend class ash::SmartDimComponentIntegrationTest;
    friend class CrOSComponentInstaller;
  #endif  // BUILDFLAG(IS_CHROMEOS)
 +  friend class ::CefComponentUpdaterImpl;
    friend class IwaKeyDistributionComponentInstallerPolicy;
-
+ 
    // Triggers an update check for a component. |id| is a value

--- a/patch/patches/tarball_deps.patch
+++ b/patch/patches/tarball_deps.patch
@@ -1,5 +1,5 @@
 diff --git DEPS DEPS
-index ecbe306a8acd4fe09ef3c11573e7cffcb5a950fd..a1df9fa8d850db7f98d8c247d4603d2e5d9deae6 100644
+index 0e724b525512444b4bd387582aa5f8c2b823557b..ec60b47b7638dd2d8da0c5f4cf592ffabd74f91b 100644
 --- DEPS
 +++ DEPS
 @@ -4213,6 +4213,7 @@ hooks = [


### PR DESCRIPTION
Change list: https://chromium.googlesource.com/chromium/src/+log/refs/tags/146.0.7680.14..refs/tags/146.0.7680.16