### PR TITLE
patch: assign unique value to DO_NOT_SEND_COOKIES

### DIFF
--- a/patch/patches/net_cookie_flags.patch
+++ b/patch/patches/net_cookie_flags.patch
@@ -7,7 +7,7 @@ index c10df92f30b1292a8243f376025e81afcefba78d..59e6208b3954635076022807edfc9a30
  LOAD_FLAG(IS_MAIN_FRAME_ORIGIN_RECENTLY_ACCESSED, 1 << 19)
  
 +// This load will not send any cookies. For CEF usage.
-+LOAD_FLAG(DO_NOT_SEND_COOKIES, 1 << 19)
++LOAD_FLAG(DO_NOT_SEND_COOKIES, 1 << 20)
 +
  // See note at top of file about why adding LoadFlags is often a bad idea.
 diff --git net/url_request/url_request_http_job.cc net/url_request/url_request_http_job.cc


### PR DESCRIPTION
Fixes #4128.

`DO_NOT_SEND_COOKIES` currently uses the same load-flag bit as Chromium
`IS_MAIN_FRAME_ORIGIN_RECENTLY_ACCESSED` on current CEF master.

This causes requests marked by Chromium for metrics collection to be treated by
CEF as "do not send cookies", which can drop same-origin `Cookie` headers.

This change assigns `DO_NOT_SEND_COOKIES` the next available unique bit for the
current branch.

This follows the existing maintenance pattern for `net_cookie_flags.patch`,
where the `DO_NOT_SEND_COOKIES` value is adjusted as Chromium load flags evolve.

In particular, `1 << 19` became the correct value in the Chromium 141 update
when that bit was free:

- https://github.com/chromiumembedded/cef/commit/35946fe8e

After that, Chromium introduced
`UpdateIsMainFrameOriginRecentlyAccessed` / `IS_MAIN_FRAME_ORIGIN_RECENTLY_ACCESSED`
on `main`:

- feature introduction:
  https://chromium.googlesource.com/chromium/src/+/0e8220ed45029fad0528e5a684ee578c8794d57d
- testing config entry:
  https://chromium.googlesource.com/chromium/src/+/6df4416418a5f7600abb0d83dfec92cb822510ee

So the CEF patch value was correct at the time of the Chromium 141 update, but
has since become stale after Chromium started using the same bit.

Historical examples:

- Introduced as `1 << 17` in the Chromium 87 update:
  https://github.com/chromiumembedded/cef/commit/015e3621a3ccaf4b90301d7b24e1fbd5abae7150
- Updated to `1 << 19` in the Chromium 117 update:
  https://github.com/chromiumembedded/cef/commit/8b46735b7
- Updated to `1 << 20` in the Chromium 120 update:
  https://github.com/chromiumembedded/cef/commit/f781ea373
- Updated back to `1 << 19` in the Chromium 141 update:
  https://github.com/chromiumembedded/cef/commit/35946fe8e

So this PR keeps the same approach and moves `DO_NOT_SEND_COOKIES` to the next
available unique bit for the current branch.
