### PR TITLE
Fix build failures in Japanese Visual Studio environment caused by Unicode characters in comments (fix issue #4145)

### DIFF
--- a/include/cef_browser.h
+++ b/include/cef_browser.h
@@ -1084,7 +1084,7 @@ class CefBrowserHost : public virtual CefBaseRefCounted {
   /// WARNING: This collapses the CDP accessibility tree and disables CDP
   /// dynamic tree updates (nodesUpdated events). The DevTools Accessibility
   /// panel will show an incomplete tree. Platform screen readers (NVDA, JAWS,
-  /// VoiceOver) are unaffected — they use a separate code path.
+  /// VoiceOver) are unaffected - they use a separate code path.
   ///
   /*--cef(added=experimental)--*/
   virtual void SetAxViewportCollapse(bool enabled) = 0;

--- a/include/cef_v8.h
+++ b/include/cef_v8.h
@@ -598,7 +598,7 @@ class CefV8Value : public virtual CefBaseRefCounted {
   ///
   /// Create a new CefV8Value object of type ArrayBuffer from a backing store
   /// previously created with CefV8BackingStore::Create(). This is a zero-copy
-  /// operation — the ArrayBuffer uses the memory already allocated by the
+  /// operation - the ArrayBuffer uses the memory already allocated by the
   /// backing store. The backing store is consumed and becomes invalid after
   /// this call. This method should only be called from within the scope of a
   /// CefRenderProcessHandler, CefV8Handler or CefV8Accessor callback, or in

--- a/include/internal/cef_types.h
+++ b/include/internal/cef_types.h
@@ -731,7 +731,7 @@ typedef struct _cef_browser_settings_t {
   /// WARNING: This collapses the CDP accessibility tree and disables CDP
   /// dynamic tree updates (nodesUpdated events). The DevTools Accessibility
   /// panel will show an incomplete tree. Platform screen readers (NVDA, JAWS,
-  /// VoiceOver) are unaffected — they use a separate code path.
+  /// VoiceOver) are unaffected - they use a separate code path.
   /// Can also be configured at runtime using
   /// CefBrowserHost::SetAxViewportCollapse.
   ///

--- a/tests/ceftests/ax_viewport_collapse_unittest.cc
+++ b/tests/ceftests/ax_viewport_collapse_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 The Chromium Embedded Framework Authors. All rights
+﻿// Copyright (c) 2026 The Chromium Embedded Framework Authors. All rights
 // reserved. Use of this source code is governed by a BSD-style license that
 // can be found in the LICENSE file.
 

--- a/tests/ceftests/string_unittest.cc
+++ b/tests/ceftests/string_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2010 The Chromium Embedded Framework Authors. All rights
+﻿// Copyright (c) 2010 The Chromium Embedded Framework Authors. All rights
 // reserved. Use of this source code is governed by a BSD-style license that
 // can be found in the LICENSE file.
 


### PR DESCRIPTION
#4145 

### **Summary**  
This pull request fixes build failures that occur in a Japanese‑locale Visual Studio environment due to UTF‑8 Unicode characters appearing inside comments.  
The issue was addressed using two methods:

1. **Replacing the problematic characters** (primary approach)  
2. **Adding a Byte Order Mark (BOM)** when replacement was difficult or unsafe

### **Details**  
Several source files contained characters such as “—”, “→”, and “≈” within comment blocks.  
In a Japanese Visual Studio environment, files that include these characters but lack a BOM are interpreted with an incorrect encoding, which leads to warnings and build failures.

To ensure consistent builds across environments, the following fixes were applied:

- **Replaced problematic Unicode characters** in files where a safe and meaningful replacement was possible  
- **Added a BOM** to files where replacing the characters was difficult, risky, or could reduce readability

### **Why this change is necessary**  
- Visual Studio (Japanese locale) fails to compile files containing UTF‑8 characters without a BOM  
- The characters appear only in comments and do not affect runtime behavior  
- Replacing them or adding a BOM eliminates encoding‑related build failures  
