### PR TITLE
Add missing include for cef_app_win.h

### DIFF
--- a/tests/cefsimple_capi/cefsimple_win.c
+++ b/tests/cefsimple_capi/cefsimple_win.c
@@ -5,6 +5,7 @@
 #include <windows.h>
 
 #include "include/capi/cef_app_capi.h"
+#include "include/internal/cef_app_win.h"
 #include "include/cef_api_hash.h"
 #include "include/cef_sandbox_win.h"
 #include "tests/cefsimple_capi/simple_app.h"

--- a/tests/cefsimple_capi/cefsimple_win.c
+++ b/tests/cefsimple_capi/cefsimple_win.c
@@ -5,9 +5,9 @@
 #include <windows.h>
 
 #include "include/capi/cef_app_capi.h"
-#include "include/internal/cef_app_win.h"
 #include "include/cef_api_hash.h"
 #include "include/cef_sandbox_win.h"
+#include "include/internal/cef_app_win.h"
 #include "tests/cefsimple_capi/simple_app.h"
 #include "tests/cefsimple_capi/simple_utils.h"
 


### PR DESCRIPTION
missing include for cef_app_win.h - fix for x86 build failure