### PR TITLE
linux: Fix oversized native window content on HiDPI displays

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -994,6 +994,7 @@ source_set("libcef_static") {
     "//third_party/zlib:minizip",
     "//ui/base",
     "//ui/base/ime",
+    "//ui/display",
     "//ui/events",
     "//ui/events:events_base",
     "//ui/gfx",

--- a/cef_paths2.gypi
+++ b/cef_paths2.gypi
@@ -562,6 +562,7 @@
       'tests/ceftests/base/test_bind.h',
       'tests/ceftests/base/to_address_unittest.cc',
       'tests/ceftests/base/weak_ptr_unittest.cc',
+      'tests/ceftests/alloy_native_window_unittest.cc',
       'tests/ceftests/browser_info_map_unittest.cc',
       'tests/ceftests/browser_settings_unittest.cc',
       'tests/ceftests/certificate_error_unittest.cc',

--- a/libcef/browser/native/browser_platform_delegate_native_linux.cc
+++ b/libcef/browser/native/browser_platform_delegate_native_linux.cc
@@ -84,24 +84,31 @@ bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
 
   // |rect| (from window_info_.bounds) is in pixels, and matches the size of the
   // |window_x11_| host window created above. However, views::Widget bounds are
-  // in DIP; DesktopWindowTreeHostLinux will scale them back to pixels using the
-  // display's device scale factor. Convert the size to DIP here so that the
-  // resulting compositor (child) window matches the pixel size of the host
-  // window. Otherwise, on displays with a device scale factor != 1, the web
-  // content is rendered larger than the host window (see issue #3396). This
-  // mirrors the Windows implementation, which converts the client rect to DIP
-  // before calling Init().
-  const float device_scale_factor = display::Screen::Get()
-                                        ->GetDisplayMatching(rect)
-                                        .device_scale_factor();
-  const gfx::Size dip_size =
-      gfx::ScaleToRoundedSize(rect.size(), 1.0f / device_scale_factor);
+  // in DIP. WindowTreeHost initially uses the primary display's scale factor
+  // because it cannot resolve the actual display until the child X11 window
+  // exists. Use that bootstrap factor for Init() so the child is created with
+  // the correct pixel size and screen bounds.
+  const float initial_device_scale_factor =
+      display::Screen::Get()->GetPrimaryDisplay().device_scale_factor();
+  const gfx::Size initial_dip_size = gfx::ScaleToRoundedSize(
+      rect.size(), 1.0f / initial_device_scale_factor);
 
   widget_delegate->Init(
       static_cast<gfx::AcceleratedWidget>(window_info_.window), web_contents_,
-      gfx::Rect(gfx::Point(), dip_size));
+      gfx::Rect(gfx::Point(), initial_dip_size));
 
   window_widget_ = widget_delegate->GetWidget();
+
+  // The child X11 window now exists, so Chromium can resolve the actual display
+  // from its native bounds. Reapply the DIP size using the scale factor that
+  // WindowTreeHost selected during InitHost().
+  const float device_scale_factor =
+      display::Screen::Get()
+          ->GetPreferredScaleFactorForWindow(window_widget_->GetNativeWindow())
+          .value_or(initial_device_scale_factor);
+  const gfx::Size dip_size =
+      gfx::ScaleToRoundedSize(rect.size(), 1.0f / device_scale_factor);
+  window_widget_->SetSize(dip_size);
   window_widget_->Show();
 
   window_x11_->Show();

--- a/libcef/browser/native/browser_platform_delegate_native_linux.cc
+++ b/libcef/browser/native/browser_platform_delegate_native_linux.cc
@@ -21,8 +21,10 @@
 
 #if BUILDFLAG(SUPPORTS_OZONE_X11)
 #include "cef/libcef/browser/native/window_x11.h"
+#include "ui/display/screen.h"
 #include "ui/events/keycodes/keyboard_code_conversion_x.h"
 #include "ui/events/keycodes/keyboard_code_conversion_xkb.h"
+#include "ui/gfx/geometry/size.h"
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host_linux.h"
 #endif
 
@@ -79,9 +81,25 @@ bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
   auto* widget_delegate = new CefNativeWidgetDelegate(
       GetBackgroundColor(), window_x11_->TopLevelAlwaysOnTop(),
       GetBoundsChangedCallback(), GetWidgetDeleteCallback());
+
+  // |rect| (from window_info_.bounds) is in pixels, and matches the size of the
+  // |window_x11_| host window created above. However, views::Widget bounds are
+  // in DIP; DesktopWindowTreeHostLinux will scale them back to pixels using the
+  // display's device scale factor. Convert the size to DIP here so that the
+  // resulting compositor (child) window matches the pixel size of the host
+  // window. Otherwise, on displays with a device scale factor != 1, the web
+  // content is rendered larger than the host window (see issue #3396). This
+  // mirrors the Windows implementation, which converts the client rect to DIP
+  // before calling Init().
+  const float device_scale_factor = display::Screen::Get()
+                                        ->GetDisplayMatching(rect)
+                                        .device_scale_factor();
+  const gfx::Size dip_size =
+      gfx::ScaleToRoundedSize(rect.size(), 1.0f / device_scale_factor);
+
   widget_delegate->Init(
       static_cast<gfx::AcceleratedWidget>(window_info_.window), web_contents_,
-      gfx::Rect(gfx::Point(), rect.size()));
+      gfx::Rect(gfx::Point(), dip_size));
 
   window_widget_ = widget_delegate->GetWidget();
   window_widget_->Show();

--- a/libcef/browser/native/browser_platform_delegate_native_linux.cc
+++ b/libcef/browser/native/browser_platform_delegate_native_linux.cc
@@ -21,12 +21,44 @@
 
 #if BUILDFLAG(SUPPORTS_OZONE_X11)
 #include "cef/libcef/browser/native/window_x11.h"
+#include "ui/aura/window.h"
+#include "ui/aura/window_tree_host.h"
+#include "ui/display/display.h"
 #include "ui/display/screen.h"
 #include "ui/events/keycodes/keyboard_code_conversion_x.h"
 #include "ui/events/keycodes/keyboard_code_conversion_xkb.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host_linux.h"
 #endif
+
+#if BUILDFLAG(SUPPORTS_OZONE_X11)
+namespace {
+
+// Returns the display whose native (pixel) bounds contain the largest portion
+// of |bounds_in_pixels|, which must be expressed in X11 root (screen) pixel
+// coordinates. display::Display::bounds() is in DIP, so each display's pixel
+// bounds are reconstructed by scaling with its device scale factor before
+// matching. Falls back to the primary display when there is no intersection.
+display::Display GetDisplayMatchingPixelBounds(
+    const gfx::Rect& bounds_in_pixels) {
+  display::Screen* screen = display::Screen::Get();
+  display::Display matched = screen->GetPrimaryDisplay();
+  int largest_area = 0;
+  for (const display::Display& display : screen->GetAllDisplays()) {
+    gfx::Rect display_pixels = gfx::ScaleToEnclosingRect(
+        display.bounds(), display.device_scale_factor());
+    display_pixels.Intersect(bounds_in_pixels);
+    const int area = display_pixels.size().GetArea();
+    if (area > largest_area) {
+      largest_area = area;
+      matched = display;
+    }
+  }
+  return matched;
+}
+
+}  // namespace
+#endif  // BUILDFLAG(SUPPORTS_OZONE_X11)
 
 CefBrowserPlatformDelegateNativeLinux::CefBrowserPlatformDelegateNativeLinux(
     const CefWindowInfo& window_info,
@@ -82,16 +114,23 @@ bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
       GetBackgroundColor(), window_x11_->TopLevelAlwaysOnTop(),
       GetBoundsChangedCallback(), GetWidgetDeleteCallback());
 
-  // |rect| (from window_info_.bounds) is in pixels, and matches the size of the
-  // |window_x11_| host window created above. However, views::Widget bounds are
-  // in DIP. WindowTreeHost initially uses the primary display's scale factor
-  // because it cannot resolve the actual display until the child X11 window
-  // exists. Use that bootstrap factor for Init() so the child is created with
-  // the correct pixel size and screen bounds.
-  const float initial_device_scale_factor =
-      display::Screen::Get()->GetPrimaryDisplay().device_scale_factor();
-  const gfx::Size initial_dip_size = gfx::ScaleToRoundedSize(
-      rect.size(), 1.0f / initial_device_scale_factor);
+  // |rect| (from window_info_.bounds) is in pixels and matches the size of the
+  // |window_x11_| host window created above, but views::Widget bounds are in
+  // DIP. Determine the device scale factor from the display the host window is
+  // actually on: translate the host window's bounds to X11 root (screen)
+  // coordinates and match them against each display's native pixel bounds. This
+  // selects the correct display when the window is placed on a non-primary
+  // monitor, instead of assuming the primary display. The child X11 window
+  // cannot be used for this: it is created at (0,0) relative to the host and
+  // would resolve to whichever display contains the root origin. As with the
+  // Windows implementation, the Init() bounds have origin (0,0); the child is
+  // positioned by the host window.
+  const gfx::Rect host_bounds_in_pixels = window_x11_->GetBoundsInScreen();
+  const float device_scale_factor =
+      GetDisplayMatchingPixelBounds(host_bounds_in_pixels)
+          .device_scale_factor();
+  const gfx::Size initial_dip_size =
+      gfx::ScaleToRoundedSize(rect.size(), 1.0f / device_scale_factor);
 
   widget_delegate->Init(
       static_cast<gfx::AcceleratedWidget>(window_info_.window), web_contents_,
@@ -99,16 +138,20 @@ bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
 
   window_widget_ = widget_delegate->GetWidget();
 
-  // The child X11 window now exists, so Chromium can resolve the actual display
-  // from its native bounds. Reapply the DIP size using the scale factor that
-  // WindowTreeHost selected during InitHost().
-  const float device_scale_factor =
-      display::Screen::Get()
-          ->GetPreferredScaleFactorForWindow(window_widget_->GetNativeWindow())
-          .value_or(initial_device_scale_factor);
-  const gfx::Size dip_size =
-      gfx::ScaleToRoundedSize(rect.size(), 1.0f / device_scale_factor);
-  window_widget_->SetSize(dip_size);
+  // The child X11 window resolves its own device scale factor from its (0,0)
+  // origin, which may differ from the host window's display on a mixed-DPI
+  // setup, leaving the web content larger or smaller than the host window (see
+  // issue #3396). Pin the compositor window's pixel size to the host window's
+  // pixel size (|rect|). Resize in pixels and keep the current origin:
+  // views::Widget::SetSize() would convert the origin to DIP and back, which is
+  // only lossless when the origin is an exact multiple of the scale factor.
+  // Keeping the pixel origin avoids that dependency and mirrors the size-only
+  // resize CefWindowX11 performs on ConfigureNotify.
+  aura::WindowTreeHost* host = window_widget_->GetNativeWindow()->GetHost();
+  gfx::Rect bounds_in_pixels = host->GetBoundsInPixels();
+  bounds_in_pixels.set_size(rect.size());
+  host->SetBoundsInPixels(bounds_in_pixels);
+
   window_widget_->Show();
 
   window_x11_->Show();

--- a/libcef/browser/native/browser_platform_delegate_native_linux.cc
+++ b/libcef/browser/native/browser_platform_delegate_native_linux.cc
@@ -120,11 +120,18 @@ bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
   // actually on: translate the host window's bounds to X11 root (screen)
   // coordinates and match them against each display's native pixel bounds. This
   // selects the correct display when the window is placed on a non-primary
-  // monitor, instead of assuming the primary display. The child X11 window
-  // cannot be used for this: it is created at (0,0) relative to the host and
-  // would resolve to whichever display contains the root origin. As with the
-  // Windows implementation, the Init() bounds have origin (0,0); the child is
-  // positioned by the host window.
+  // monitor, instead of assuming the primary display.
+  //
+  // The scale is computed here rather than deferred to the child window because
+  // this early in initialization the child does not yet resolve to the correct
+  // display. Its geometry in root coordinates is not established yet (the
+  // GeometryCache behind X11Window::GetBoundsInPixels(), which X11ScreenOzone
+  // reads, has not accumulated the parent offsets), and
+  // DesktopWindowTreeHostPlatform::GetRootTransform() runs before its
+  // platform_window exists during CreateXWindow(), so the child falls back to
+  // the primary display's scale. As with the Windows implementation, the
+  // Init() bounds have origin (0,0); the child is positioned by the host
+  // window.
   const gfx::Rect host_bounds_in_pixels = window_x11_->GetBoundsInScreen();
   const float device_scale_factor =
       GetDisplayMatchingPixelBounds(host_bounds_in_pixels)
@@ -138,12 +145,13 @@ bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
 
   window_widget_ = widget_delegate->GetWidget();
 
-  // The child X11 window resolves its own device scale factor from its (0,0)
-  // origin, which may differ from the host window's display on a mixed-DPI
-  // setup, leaving the web content larger or smaller than the host window (see
-  // issue #3396). Pin the compositor to the host window's exact pixel size
-  // (|rect|) with a size-only child configure. See SetChildSizeInPixels() for
-  // why aura::WindowTreeHost::SetBoundsInPixels() cannot be used here.
+  // For the same reason, this early in initialization the child compositor is
+  // sized using the primary display's scale rather than the host window's (see
+  // above), which on a mixed-DPI setup leaves the web content larger or smaller
+  // than the host window (see issue #3396). Pin the compositor to the host
+  // window's exact pixel size (|rect|) with a size-only child configure. See
+  // SetChildSizeInPixels() for why aura::WindowTreeHost::SetBoundsInPixels()
+  // cannot be used here.
   window_x11_->SetChildSizeInPixels(rect.size());
 
   window_widget_->Show();

--- a/libcef/browser/native/browser_platform_delegate_native_linux.cc
+++ b/libcef/browser/native/browser_platform_delegate_native_linux.cc
@@ -21,8 +21,6 @@
 
 #if BUILDFLAG(SUPPORTS_OZONE_X11)
 #include "cef/libcef/browser/native/window_x11.h"
-#include "ui/aura/window.h"
-#include "ui/aura/window_tree_host.h"
 #include "ui/display/display.h"
 #include "ui/display/screen.h"
 #include "ui/events/keycodes/keyboard_code_conversion_x.h"
@@ -36,17 +34,19 @@ namespace {
 
 // Returns the display whose native (pixel) bounds contain the largest portion
 // of |bounds_in_pixels|, which must be expressed in X11 root (screen) pixel
-// coordinates. display::Display::bounds() is in DIP, so each display's pixel
-// bounds are reconstructed by scaling with its device scale factor before
-// matching. Falls back to the primary display when there is no intersection.
+// coordinates. On X11 each display carries its exact pixel geometry via
+// native_origin()/GetSizeInPixel(), so match against that directly (as
+// X11ScreenOzone::DisplayBoundsInPixels() does). display::Display::bounds() is
+// unsuitable here: it is in DIP, and a non-primary display's DIP origin does
+// not map back to its pixel origin by scaling (under mixed DPI the two layouts
+// diverge). Falls back to the primary display when there is no intersection.
 display::Display GetDisplayMatchingPixelBounds(
     const gfx::Rect& bounds_in_pixels) {
   display::Screen* screen = display::Screen::Get();
   display::Display matched = screen->GetPrimaryDisplay();
   int largest_area = 0;
   for (const display::Display& display : screen->GetAllDisplays()) {
-    gfx::Rect display_pixels = gfx::ScaleToEnclosingRect(
-        display.bounds(), display.device_scale_factor());
+    gfx::Rect display_pixels(display.native_origin(), display.GetSizeInPixel());
     display_pixels.Intersect(bounds_in_pixels);
     const int area = display_pixels.size().GetArea();
     if (area > largest_area) {
@@ -141,16 +141,10 @@ bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
   // The child X11 window resolves its own device scale factor from its (0,0)
   // origin, which may differ from the host window's display on a mixed-DPI
   // setup, leaving the web content larger or smaller than the host window (see
-  // issue #3396). Pin the compositor window's pixel size to the host window's
-  // pixel size (|rect|). Resize in pixels and keep the current origin:
-  // views::Widget::SetSize() would convert the origin to DIP and back, which is
-  // only lossless when the origin is an exact multiple of the scale factor.
-  // Keeping the pixel origin avoids that dependency and mirrors the size-only
-  // resize CefWindowX11 performs on ConfigureNotify.
-  aura::WindowTreeHost* host = window_widget_->GetNativeWindow()->GetHost();
-  gfx::Rect bounds_in_pixels = host->GetBoundsInPixels();
-  bounds_in_pixels.set_size(rect.size());
-  host->SetBoundsInPixels(bounds_in_pixels);
+  // issue #3396). Pin the compositor to the host window's exact pixel size
+  // (|rect|) with a size-only child configure. See SetChildSizeInPixels() for
+  // why aura::WindowTreeHost::SetBoundsInPixels() cannot be used here.
+  window_x11_->SetChildSizeInPixels(rect.size());
 
   window_widget_->Show();
 

--- a/libcef/browser/native/window_x11.cc
+++ b/libcef/browser/native/window_x11.cc
@@ -324,26 +324,31 @@ void CefWindowX11::SetBounds(const gfx::Rect& bounds) {
   }
 }
 
-void CefWindowX11::SetChildSizeInPixels(const gfx::Size& size_in_pixels) {
+bool CefWindowX11::SetChildSizeInPixels(const gfx::Size& size_in_pixels) {
   if (xwindow_ == x11::Window::None) {
-    return;
+    return false;
   }
 
   // Resize the child DesktopWindowTreeHostLinux directly with a size-only X11
-  // configure, mirroring the resize CefWindowX11 performs in ProcessXEvent()
-  // on ConfigureNotify. Going through aura::WindowTreeHost::SetBoundsInPixels()
-  // instead would route into X11Window::SetBoundsInPixels(), whose
+  // configure. Going through aura::WindowTreeHost::SetBoundsInPixels() instead
+  // would route into X11Window::SetBoundsInPixels(), whose
   // AdjustSizeForDisplay() returns size - 1 when the requested size matches a
   // monitor size (a top-level fullscreen-avoidance workaround) and would leave
-  // a monitor-sized child one pixel short.
+  // a monitor-sized child one pixel short. Both the initial sizing in
+  // CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() and the
+  // ConfigureNotify handling in ProcessXEvent() go through here, so bypassing
+  // AdjustSizeForDisplay() stays consistent across the two paths.
   auto child = FindChild(connection_, xwindow_);
-  if (child != x11::Window::None) {
-    connection_->ConfigureWindow(x11::ConfigureWindowRequest{
-        .window = child,
-        .width = size_in_pixels.width(),
-        .height = size_in_pixels.height(),
-    });
+  if (child == x11::Window::None) {
+    return false;
   }
+
+  connection_->ConfigureWindow(x11::ConfigureWindowRequest{
+      .window = child,
+      .width = size_in_pixels.width(),
+      .height = size_in_pixels.height(),
+  });
+  return true;
 }
 
 gfx::Rect CefWindowX11::GetBoundsInScreen() {
@@ -427,16 +432,8 @@ void CefWindowX11::ProcessXEvent(const x11::Event& event) {
                         configure->height);
 
     if (browser_.get()) {
-      auto child = FindChild(connection_, xwindow_);
-      if (child != x11::Window::None) {
-        // Resize the child DesktopWindowTreeHostLinux to match this window.
-        x11::ConfigureWindowRequest req{
-            .window = child,
-            .width = bounds_.width(),
-            .height = bounds_.height(),
-        };
-        connection_->ConfigureWindow(req);
-
+      // Resize the child DesktopWindowTreeHostLinux to match this window.
+      if (SetChildSizeInPixels(bounds_.size())) {
         browser_->NotifyMoveOrResizeStarted();
       }
     }

--- a/libcef/browser/native/window_x11.cc
+++ b/libcef/browser/native/window_x11.cc
@@ -324,6 +324,28 @@ void CefWindowX11::SetBounds(const gfx::Rect& bounds) {
   }
 }
 
+void CefWindowX11::SetChildSizeInPixels(const gfx::Size& size_in_pixels) {
+  if (xwindow_ == x11::Window::None) {
+    return;
+  }
+
+  // Resize the child DesktopWindowTreeHostLinux directly with a size-only X11
+  // configure, mirroring the resize CefWindowX11 performs in ProcessXEvent()
+  // on ConfigureNotify. Going through aura::WindowTreeHost::SetBoundsInPixels()
+  // instead would route into X11Window::SetBoundsInPixels(), whose
+  // AdjustSizeForDisplay() returns size - 1 when the requested size matches a
+  // monitor size (a top-level fullscreen-avoidance workaround) and would leave
+  // a monitor-sized child one pixel short.
+  auto child = FindChild(connection_, xwindow_);
+  if (child != x11::Window::None) {
+    connection_->ConfigureWindow(x11::ConfigureWindowRequest{
+        .window = child,
+        .width = size_in_pixels.width(),
+        .height = size_in_pixels.height(),
+    });
+  }
+}
+
 gfx::Rect CefWindowX11::GetBoundsInScreen() {
   if (auto coords =
           connection_

--- a/libcef/browser/native/window_x11.h
+++ b/libcef/browser/native/window_x11.h
@@ -48,8 +48,9 @@ class CefWindowX11 : public ui::PlatformEventDispatcher,
   // Resizes the child compositor window to |size_in_pixels| with a size-only
   // X11 configure. Unlike aura::WindowTreeHost::SetBoundsInPixels(), this does
   // not run the size through X11Window::AdjustSizeForDisplay(), so a
-  // monitor-sized child keeps its exact requested pixel size.
-  void SetChildSizeInPixels(const gfx::Size& size_in_pixels);
+  // monitor-sized child keeps its exact requested pixel size. Returns true if a
+  // child window was found and configured.
+  bool SetChildSizeInPixels(const gfx::Size& size_in_pixels);
 
   gfx::Rect GetBoundsInScreen();
 

--- a/libcef/browser/native/window_x11.h
+++ b/libcef/browser/native/window_x11.h
@@ -45,6 +45,12 @@ class CefWindowX11 : public ui::PlatformEventDispatcher,
 
   void SetBounds(const gfx::Rect& bounds);
 
+  // Resizes the child compositor window to |size_in_pixels| with a size-only
+  // X11 configure. Unlike aura::WindowTreeHost::SetBoundsInPixels(), this does
+  // not run the size through X11Window::AdjustSizeForDisplay(), so a
+  // monitor-sized child keeps its exact requested pixel size.
+  void SetChildSizeInPixels(const gfx::Size& size_in_pixels);
+
   gfx::Rect GetBoundsInScreen();
 
   views::DesktopWindowTreeHostLinux* GetHost();

--- a/tests/ceftests/alloy_native_window_unittest.cc
+++ b/tests/ceftests/alloy_native_window_unittest.cc
@@ -1,0 +1,290 @@
+// Copyright 2026 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+#include "include/base/cef_build.h"
+
+// Alloy style browsers created with a native X11 parent window
+// (CefWindowInfo::SetAsChild + CEF_RUNTIME_STYLE_ALLOY) are hosted by a
+// CefWindowX11 (libcef/browser/native/window_x11.cc), under which the Ozone
+// compositor (DesktopWindowTreeHostLinux) window is created as a child. This
+// test is Linux/X11 only.
+#if defined(OS_LINUX) && defined(CEF_X11)
+
+// Regression coverage for issue #3396: on a HiDPI display the Ozone child
+// compositor was sized in DIP-as-pixels, leaving it scale-times too large
+// inside the host window. CreateHostWindow() now derives the scale from the
+// host window's actual display and pins the child to the exact requested pixel
+// size, so the host and its child are the requested size at any scale.
+//
+// The invariant asserted here (host == child == requested pixels) holds at
+// every device scale factor, so the test can run in the default suite. It is a
+// trivial pass at the default scale of 1.0, where the buggy and fixed code
+// produce the same size. The regression only becomes observable at a non-unit
+// scale, so run it as a dedicated pass:
+//
+//   xvfb-run -a ceftests --no-sandbox --force-device-scale-factor=1.25 \
+//     --gtest_filter=AlloyChildWindowTest.InitialPixelSize
+//
+// At 1.25 the pre-fix child is 1000x750 inside the 800x600 host; with the fix
+// both are 800x600 immediately. The requested size is kept different from the
+// Xvfb monitor size so this stays independent of the separate fullscreen-size
+// workaround in X11Window::AdjustSizeForDisplay(). Note that a uniform forced
+// scale exercises the initial-size invariant only; the multi-monitor display
+// selection in GetDisplayMatchingPixelBounds() needs real mixed-DPI hardware.
+
+#include "include/base/cef_callback.h"
+#include "include/base/cef_logging.h"
+#include "include/cef_browser.h"
+#include "include/cef_command_line.h"
+#include "include/wrapper/cef_closure_task.h"
+#include "tests/ceftests/test_handler.h"
+#include "tests/ceftests/thread_helper.h"
+#include "tests/ceftests/track_callback.h"
+#include "tests/gtest/include/gtest/gtest.h"
+
+#include <X11/Xlib.h>
+
+namespace {
+
+const char kTestUrl[] = "https://tests.test/alloy-native-window.html";
+const char kTestContent[] =
+    "<html><body>Alloy Native Window Test</body></html>";
+
+// Requested browser size, in pixels. Kept different from any typical Xvfb
+// monitor size so the assertion is independent of the fullscreen-size
+// workaround in X11Window::AdjustSizeForDisplay().
+constexpr int kRequestedWidth = 800;
+constexpr int kRequestedHeight = 600;
+
+// Number of UI thread task round trips used to let previously posted teardown
+// tasks (browser destruction, Widget destruction) complete before continuing.
+constexpr size_t kTeardownRoundTrips = 3;
+
+class AlloyNativeWindowTestHandler : public TestHandler {
+ public:
+  AlloyNativeWindowTestHandler() = default;
+
+  AlloyNativeWindowTestHandler(const AlloyNativeWindowTestHandler&) = delete;
+  AlloyNativeWindowTestHandler& operator=(const AlloyNativeWindowTestHandler&) =
+      delete;
+
+  void RunTest() override {
+    AddResource(kTestUrl, kTestContent, "text/html");
+
+    // Browser lifetime is managed by this test (see OnAfterCreated), so test
+    // completion must be signaled explicitly.
+    SetSignalTestCompletionCount(1);
+
+    CefPostTask(TID_UI,
+                base::BindOnce(
+                    &AlloyNativeWindowTestHandler::CreateChildBrowser, this));
+    SetTestTimeout();
+  }
+
+  // The Alloy browser is hosted by a CefWindowX11, not a test-managed Views
+  // window, so skip the TestHandler implementation and track the browser
+  // directly.
+  void OnAfterCreated(CefRefPtr<CefBrowser> browser) override {
+    EXPECT_UI_THREAD();
+    EXPECT_FALSE(browser_);
+    browser_ = browser;
+
+    // Check the size the browser was created with, once its initialization X11
+    // requests have flushed. Use task round trips rather than a resize: a
+    // manual parent resize would route through CefWindowX11::ProcessXEvent()
+    // and resize the child to match, masking #3396.
+    RunAfterUITaskRoundTrips(
+        2, base::BindOnce(
+               &AlloyNativeWindowTestHandler::CheckInitialPixelSize, this));
+  }
+
+  void OnBeforeClose(CefRefPtr<CefBrowser> browser) override {
+    EXPECT_UI_THREAD();
+    EXPECT_TRUE(browser_);
+    EXPECT_TRUE(browser->IsSame(browser_));
+    browser_ = nullptr;
+
+    // Allow the posted browser and Widget teardown tasks to complete before
+    // finishing the test.
+    RunAfterUITaskRoundTrips(
+        kTeardownRoundTrips,
+        base::BindOnce(&AlloyNativeWindowTestHandler::FinishTest, this));
+  }
+
+  void DestroyTest() override {
+    EXPECT_UI_THREAD();
+
+    if (browser_) {
+      CloseBrowser(browser_, /*force_close=*/true);
+    }
+
+    TestHandler::DestroyTest();
+  }
+
+  void OnTestTimeout(int timeout_ms, bool treat_as_error) override {
+    timed_out_ = true;
+    TestHandler::OnTestTimeout(timeout_ms, treat_as_error);
+  }
+
+ private:
+  void CreateChildBrowser() {
+    EXPECT_UI_THREAD();
+
+    parent_window_ = CreateParentWindow();
+    if (parent_window_ == kNullWindowHandle) {
+      ADD_FAILURE() << "Failed to create native parent window";
+      DestroyTest();
+      SignalTestCompletion();
+      return;
+    }
+
+    CefWindowInfo window_info;
+    window_info.SetAsChild(
+        parent_window_,
+        CefRect(0, 0, kRequestedWidth, kRequestedHeight));
+
+    // This is the native (CefWindowX11) window path affected by issue #3396.
+    window_info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;
+
+    CefBrowserSettings settings;
+    CefBrowserHost::CreateBrowser(window_info, this, kTestUrl, settings,
+                                  /*extra_info=*/nullptr,
+                                  /*request_context=*/nullptr);
+  }
+
+  void CheckInitialPixelSize() {
+    EXPECT_UI_THREAD();
+    ASSERT_TRUE(browser_);
+
+    const CefWindowHandle host_handle =
+        browser_->GetHost()->GetWindowHandle();
+    EXPECT_NE(host_handle, kNullWindowHandle);
+
+    // The browser's configure requests are issued on its own X connection and
+    // flushed during the task round trips above; round-trip our connection to
+    // the server (XSync) so they are reflected before we query geometry.
+    XSync(xdisplay_, /*discard=*/False);
+
+    const ::Window host = static_cast<::Window>(host_handle);
+
+    // The CefWindowX11 host must contain exactly one child: the Ozone
+    // DesktopWindowTreeHostLinux compositor window (mirrors FindChild() in
+    // libcef/browser/native/window_x11.cc).
+    ::Window root = 0, parent = 0;
+    ::Window* children = nullptr;
+    unsigned int nchildren = 0;
+    if (XQueryTree(xdisplay_, host, &root, &parent, &children, &nchildren) &&
+        nchildren == 1) {
+      const ::Window child = children[0];
+
+      XWindowAttributes host_attrs = {};
+      XWindowAttributes child_attrs = {};
+      EXPECT_TRUE(XGetWindowAttributes(xdisplay_, host, &host_attrs));
+      EXPECT_TRUE(XGetWindowAttributes(xdisplay_, child, &child_attrs));
+
+      // The requested size is in pixels; after the fix both the host and the
+      // child compositor are exactly that size, independent of scale.
+      EXPECT_EQ(kRequestedWidth, host_attrs.width);
+      EXPECT_EQ(kRequestedHeight, host_attrs.height);
+      EXPECT_EQ(kRequestedWidth, child_attrs.width);
+      EXPECT_EQ(kRequestedHeight, child_attrs.height);
+
+      const std::string forced_scale =
+          CefCommandLine::GetGlobalCommandLine()
+              ->GetSwitchValue("force-device-scale-factor")
+              .ToString();
+      LOG(INFO) << "AlloyChildWindowTest.InitialPixelSize:"
+                << " requested=" << kRequestedWidth << "x" << kRequestedHeight
+                << " host=" << host_attrs.width << "x" << host_attrs.height
+                << " child=" << child_attrs.width << "x" << child_attrs.height
+                << " force-device-scale-factor='"
+                << (forced_scale.empty() ? "(unset; 1.0, trivial pass)"
+                                         : forced_scale)
+                << "'";
+    } else {
+      ADD_FAILURE() << "Expected exactly one child of the host window, got "
+                    << nchildren;
+    }
+
+    if (children) {
+      XFree(children);
+    }
+
+    DestroyTest();
+  }
+
+  // Last step; called after the browser has closed and teardown tasks have
+  // completed.
+  void FinishTest() {
+    EXPECT_UI_THREAD();
+
+    DestroyParentWindow();
+
+    if (!timed_out_) {
+      SignalTestCompletion();
+    }
+  }
+
+  // Executes |callback| on the UI thread after |count| task round trips.
+  void RunAfterUITaskRoundTrips(size_t count, base::OnceClosure callback) {
+    EXPECT_UI_THREAD();
+    if (count == 0) {
+      std::move(callback).Run();
+      return;
+    }
+    CefPostTask(
+        TID_UI,
+        base::BindOnce(&AlloyNativeWindowTestHandler::RunAfterUITaskRoundTrips,
+                       this, count - 1, std::move(callback)));
+  }
+
+  CefWindowHandle CreateParentWindow() {
+    EXPECT_UI_THREAD();
+    xdisplay_ = XOpenDisplay(nullptr);
+    if (!xdisplay_) {
+      return kNullWindowHandle;
+    }
+    const ::Window window = XCreateSimpleWindow(
+        xdisplay_, DefaultRootWindow(xdisplay_), 0, 0, kRequestedWidth,
+        kRequestedHeight, /*border_width=*/0, /*border=*/0, /*background=*/0);
+    XMapWindow(xdisplay_, window);
+    XFlush(xdisplay_);
+    return static_cast<CefWindowHandle>(window);
+  }
+
+  // Safe to call multiple times.
+  void DestroyParentWindow() {
+    EXPECT_UI_THREAD();
+    if (parent_window_ == kNullWindowHandle) {
+      return;
+    }
+    XDestroyWindow(xdisplay_, parent_window_);
+    XFlush(xdisplay_);
+    XCloseDisplay(xdisplay_);
+    xdisplay_ = nullptr;
+    parent_window_ = kNullWindowHandle;
+  }
+
+  CefRefPtr<CefBrowser> browser_;
+  CefWindowHandle parent_window_ = kNullWindowHandle;
+  ::Display* xdisplay_ = nullptr;
+  bool timed_out_ = false;
+
+  IMPLEMENT_REFCOUNTING(AlloyNativeWindowTestHandler);
+};
+
+}  // namespace
+
+// Verifies that an Alloy browser created as a native X11 child is sized to the
+// exact requested pixel size (host and Ozone child), which regressed on HiDPI
+// displays as issue #3396. Meaningful under --force-device-scale-factor; see
+// the file comment for the regression invocation.
+TEST(AlloyChildWindowTest, InitialPixelSize) {
+  CefRefPtr<AlloyNativeWindowTestHandler> handler =
+      new AlloyNativeWindowTestHandler();
+  handler->ExecuteTest();
+  ReleaseAndWaitForDestructor(handler);
+}
+
+#endif  // defined(OS_LINUX) && defined(CEF_X11)


### PR DESCRIPTION
Fixes #3396.

On Ozone X11, an Alloy-style browser in a native (non-Views) parent window renders its web content device-scale-factor times too large on displays where DSF != 1, and only fits after a manual resize. `CreateHostWindow()` creates the `CefWindowX11` host at the pixel bounds from `window_info_.bounds`, but passes those same pixel dimensions as the `views::Widget::InitParams::bounds`, which are interpreted as DIP. `DesktopWindowTreeHostLinux` then scales them back up by the device scale factor, so the compositor child window ends up `size * DSF` pixels inside a `size`-pixel host. (The "fixes on resize" behavior comes from `CefWindowX11::ProcessXEvent()` forcing the child to the parent's pixel size on `ConfigureNotify`, which doesn't run at creation time.)
