### PR TITLE
linux: Fix callbacks to CefPrintHandler (fixes #4130)

### DIFF
--- a/libcef/browser/chrome/chrome_browser_main_extra_parts_cef.cc
+++ b/libcef/browser/chrome/chrome_browser_main_extra_parts_cef.cc
@@ -27,7 +27,16 @@
 
 ChromeBrowserMainExtraPartsCef::ChromeBrowserMainExtraPartsCef() = default;
 
-ChromeBrowserMainExtraPartsCef::~ChromeBrowserMainExtraPartsCef() = default;
+ChromeBrowserMainExtraPartsCef::~ChromeBrowserMainExtraPartsCef() {
+#if BUILDFLAG(IS_LINUX)
+  // Clear the global printing delegate pointer before |printing_delegate_| is
+  // destroyed so it does not dangle. |print_dialog_factory_| unregisters itself
+  // via the PrintDialogLinuxFactory destructor.
+  if (printing_delegate_) {
+    ui::PrintingContextLinuxDelegate::SetInstance(nullptr);
+  }
+#endif
+}
 
 void ChromeBrowserMainExtraPartsCef::PostProfileInit(Profile* profile,
                                                      bool is_initial_profile) {
@@ -91,16 +100,21 @@ void ChromeBrowserMainExtraPartsCef::ToolkitInitialized() {
       CreateChromeConstrainedWindowViewsClient()));
 
 #if BUILDFLAG(IS_LINUX)
-  auto printing_delegate = new CefPrintingContextLinuxDelegate();
-  auto default_delegate =
-      ui::PrintingContextLinuxDelegate::SetInstance(printing_delegate);
-  printing_delegate->SetDefaultDelegate(default_delegate);
+  printing_delegate_ = std::make_unique<CefPrintingContextLinuxDelegate>();
+  auto* default_delegate =
+      ui::PrintingContextLinuxDelegate::SetInstance(printing_delegate_.get());
+  printing_delegate_->SetDefaultDelegate(default_delegate);
 
   // Replace the default factory registered by
-  // ChromeBrowserMainExtraPartsViewsLinux with one that routes through the
-  // delegate above. SetPrintDialogFactory() requires a null reset first.
+  // ChromeBrowserMainExtraPartsViewsLinux with a CefPrintDialogFactory, which
+  // routes browsers that have a CefPrintHandler through the delegate above and
+  // otherwise falls back to its PrintDialogLinuxFactory base (preserving the
+  // normal portal/LinuxUi dialog selection). SetPrintDialogFactory() only
+  // accepts a new factory when none is currently set, so clear the existing one
+  // first; the PrintDialogLinuxFactory base constructor then registers this
+  // instance. Owned by |print_dialog_factory_| so it unregisters itself at
+  // shutdown.
   printing::PrintingContextLinux::SetPrintDialogFactory(nullptr);
-  printing::PrintingContextLinux::SetPrintDialogFactory(
-      new CefPrintDialogFactory());
+  print_dialog_factory_ = std::make_unique<CefPrintDialogFactory>();
 #endif  // BUILDFLAG(IS_LINUX)
 }

--- a/libcef/browser/chrome/chrome_browser_main_extra_parts_cef.cc
+++ b/libcef/browser/chrome/chrome_browser_main_extra_parts_cef.cc
@@ -95,5 +95,12 @@ void ChromeBrowserMainExtraPartsCef::ToolkitInitialized() {
   auto default_delegate =
       ui::PrintingContextLinuxDelegate::SetInstance(printing_delegate);
   printing_delegate->SetDefaultDelegate(default_delegate);
+
+  // Replace the default factory registered by
+  // ChromeBrowserMainExtraPartsViewsLinux with one that routes through the
+  // delegate above. SetPrintDialogFactory() requires a null reset first.
+  printing::PrintingContextLinux::SetPrintDialogFactory(nullptr);
+  printing::PrintingContextLinux::SetPrintDialogFactory(
+      new CefPrintDialogFactory());
 #endif  // BUILDFLAG(IS_LINUX)
 }

--- a/libcef/browser/chrome/chrome_browser_main_extra_parts_cef.h
+++ b/libcef/browser/chrome/chrome_browser_main_extra_parts_cef.h
@@ -8,8 +8,15 @@
 #include <memory>
 
 #include "base/task/single_thread_task_runner.h"
+#include "build/build_config.h"
 #include "cef/libcef/browser/request_context_impl.h"
 #include "chrome/browser/chrome_browser_main_extra_parts.h"
+
+#if BUILDFLAG(IS_LINUX)
+#include "printing/printing_context_linux.h"
+
+class CefPrintingContextLinuxDelegate;
+#endif
 
 // Wrapper that owns and initialize the browser memory-related extra parts.
 class ChromeBrowserMainExtraPartsCef : public ChromeBrowserMainExtraParts {
@@ -53,6 +60,17 @@ class ChromeBrowserMainExtraPartsCef : public ChromeBrowserMainExtraParts {
   scoped_refptr<base::SingleThreadTaskRunner> background_task_runner_;
   scoped_refptr<base::SingleThreadTaskRunner> user_visible_task_runner_;
   scoped_refptr<base::SingleThreadTaskRunner> user_blocking_task_runner_;
+
+#if BUILDFLAG(IS_LINUX)
+  // Owns the printing delegate and print dialog factory registered in
+  // ToolkitInitialized(). |printing_delegate_| is declared first so it is
+  // destroyed after |print_dialog_factory_|; the destructor clears the global
+  // delegate pointer before it is destroyed, and the factory unregisters itself
+  // via the PrintDialogLinuxFactory destructor.
+  std::unique_ptr<CefPrintingContextLinuxDelegate> printing_delegate_;
+  std::unique_ptr<printing::PrintingContextLinux::PrintDialogFactory>
+      print_dialog_factory_;
+#endif
 };
 
 #endif  // CEF_LIBCEF_BROWSER_CHROME_CHROME_BROWSER_MAIN_EXTRA_PARTS_CEF_H_

--- a/libcef/browser/printing/print_dialog_linux.cc
+++ b/libcef/browser/printing/print_dialog_linux.cc
@@ -54,6 +54,47 @@ CefRefPtr<CefPrintHandler> GetPrintHandlerForBrowser(
   return nullptr;
 }
 
+// Owned by PrintingContextLinux via a std::unique_ptr (the M145 ownership
+// model) and forwards to the reference-counted CefPrintDialogLinux, which must
+// outlive the PrintingContext until an async CefPrintHandler job completes.
+// Destroying the proxy calls ReleaseDialog() to drop the context's reference;
+// outstanding callbacks keep the dialog alive until the job finishes.
+class CefPrintDialogLinuxProxy : public printing::PrintDialogLinuxInterface {
+ public:
+  explicit CefPrintDialogLinuxProxy(CefRefPtr<CefPrintDialogLinux> dialog)
+      : dialog_(std::move(dialog)) {}
+
+  CefPrintDialogLinuxProxy(const CefPrintDialogLinuxProxy&) = delete;
+  CefPrintDialogLinuxProxy& operator=(const CefPrintDialogLinuxProxy&) = delete;
+
+  ~CefPrintDialogLinuxProxy() override { dialog_->ReleaseDialog(); }
+
+  // printing::PrintDialogLinuxInterface:
+  void UseDefaultSettings() override { dialog_->UseDefaultSettings(); }
+  void UpdateSettings(
+      std::unique_ptr<printing::PrintSettings> settings) override {
+    dialog_->UpdateSettings(std::move(settings));
+  }
+#if BUILDFLAG(ENABLE_OOP_PRINTING_NO_OOP_BASIC_PRINT_DIALOG)
+  void LoadPrintSettings(const printing::PrintSettings& settings) override {
+    dialog_->LoadPrintSettings(settings);
+  }
+#endif
+  void ShowDialog(
+      gfx::NativeView parent_view,
+      bool has_selection,
+      PrintingContextLinux::PrintSettingsCallback callback) override {
+    dialog_->ShowDialog(parent_view, has_selection, std::move(callback));
+  }
+  void PrintDocument(const printing::MetafilePlayer& metafile,
+                     const std::u16string& document_name) override {
+    dialog_->PrintDocument(metafile, document_name);
+  }
+
+ private:
+  CefRefPtr<CefPrintDialogLinux> dialog_;
+};
+
 }  // namespace
 
 class CefPrintDialogCallbackImpl : public CefPrintDialogCallback {
@@ -148,7 +189,7 @@ CefPrintingContextLinuxDelegate::CreatePrintDialog(
       DCHECK(interface);
     }
   } else {
-    interface = base::WrapUnique<printing::PrintDialogLinuxInterface>(
+    interface = std::make_unique<CefPrintDialogLinuxProxy>(
         new CefPrintDialogLinux(context, browser, handler));
   }
 
@@ -196,6 +237,35 @@ void CefPrintingContextLinuxDelegate::SetDefaultDelegate(
   DCHECK(!default_delegate_);
   default_delegate_ = delegate;
 }
+
+CefPrintDialogFactory::CefPrintDialogFactory() = default;
+
+std::unique_ptr<printing::PrintDialogLinuxInterface>
+CefPrintDialogFactory::CreatePrintDialog(
+    printing::PrintingContextLinux* context,
+    bool show_system_dialog) {
+  // Route dialog creation back through CefPrintingContextLinuxDelegate so that
+  // CefPrintHandler is used. The delegate falls back to the default (GTK)
+  // implementation when no handler is provided.
+  if (auto* delegate = ui::PrintingContextLinuxDelegate::instance()) {
+    return delegate->CreatePrintDialog(context);
+  }
+  return nullptr;
+}
+
+#if BUILDFLAG(ENABLE_OOP_PRINTING_NO_OOP_BASIC_PRINT_DIALOG)
+std::unique_ptr<printing::PrintDialogLinuxInterface>
+CefPrintDialogFactory::CreatePrintDialogForSettings(
+    printing::PrintingContextLinux* context,
+    const printing::PrintSettings& settings) {
+  // The caller applies |settings| via PrintDialogLinuxInterface::
+  // LoadPrintSettings() after the dialog is created.
+  if (auto* delegate = ui::PrintingContextLinuxDelegate::instance()) {
+    return delegate->CreatePrintDialog(context);
+  }
+  return nullptr;
+}
+#endif
 
 CefPrintDialogLinux::CefPrintDialogLinux(PrintingContextLinux* context,
                                          CefRefPtr<CefBrowserHostBase> browser,

--- a/libcef/browser/printing/print_dialog_linux.cc
+++ b/libcef/browser/printing/print_dialog_linux.cc
@@ -54,6 +54,12 @@ CefRefPtr<CefPrintHandler> GetPrintHandlerForBrowser(
   return nullptr;
 }
 
+// Returns true when the browser associated with |context| provides a
+// CefPrintHandler.
+bool ContextHasPrintHandler(printing::PrintingContextLinux* context) {
+  return GetPrintHandlerForBrowser(GetBrowserForContext(context)) != nullptr;
+}
+
 // Owned by PrintingContextLinux via a std::unique_ptr (the M145 ownership
 // model) and forwards to the reference-counted CefPrintDialogLinux, which must
 // outlive the PrintingContext until an async CefPrintHandler job completes.
@@ -244,13 +250,20 @@ std::unique_ptr<printing::PrintDialogLinuxInterface>
 CefPrintDialogFactory::CreatePrintDialog(
     printing::PrintingContextLinux* context,
     bool show_system_dialog) {
-  // Route dialog creation back through CefPrintingContextLinuxDelegate so that
-  // CefPrintHandler is used. The delegate falls back to the default (GTK)
-  // implementation when no handler is provided.
-  if (auto* delegate = ui::PrintingContextLinuxDelegate::instance()) {
-    return delegate->CreatePrintDialog(context);
+  // Only intercept when the associated browser provides a CefPrintHandler;
+  // route those through CefPrintingContextLinuxDelegate so the handler is used.
+  if (ContextHasPrintHandler(context)) {
+    if (auto* delegate = ui::PrintingContextLinuxDelegate::instance()) {
+      return delegate->CreatePrintDialog(context);
+    }
+    return nullptr;
   }
-  return nullptr;
+
+  // Otherwise fall back to the base implementation so that handler-less
+  // printing keeps Chromium's dialog selection, including the
+  // |show_system_dialog| based XDG portal branch.
+  return PrintDialogLinuxFactory::CreatePrintDialog(context,
+                                                    show_system_dialog);
 }
 
 #if BUILDFLAG(ENABLE_OOP_PRINTING_NO_OOP_BASIC_PRINT_DIALOG)
@@ -258,12 +271,19 @@ std::unique_ptr<printing::PrintDialogLinuxInterface>
 CefPrintDialogFactory::CreatePrintDialogForSettings(
     printing::PrintingContextLinux* context,
     const printing::PrintSettings& settings) {
-  // The caller applies |settings| via PrintDialogLinuxInterface::
-  // LoadPrintSettings() after the dialog is created.
-  if (auto* delegate = ui::PrintingContextLinuxDelegate::instance()) {
-    return delegate->CreatePrintDialog(context);
+  // As above, only intercept when a CefPrintHandler is present. The caller
+  // applies |settings| via PrintDialogLinuxInterface::LoadPrintSettings()
+  // after the dialog is created.
+  if (ContextHasPrintHandler(context)) {
+    if (auto* delegate = ui::PrintingContextLinuxDelegate::instance()) {
+      return delegate->CreatePrintDialog(context);
+    }
+    return nullptr;
   }
-  return nullptr;
+
+  // Otherwise fall back to the base implementation's settings-based selection.
+  return PrintDialogLinuxFactory::CreatePrintDialogForSettings(context,
+                                                               settings);
 }
 #endif
 

--- a/libcef/browser/printing/print_dialog_linux.h
+++ b/libcef/browser/printing/print_dialog_linux.h
@@ -12,6 +12,7 @@
 #include "base/task/sequenced_task_runner_helpers.h"
 #include "cef/include/cef_print_handler.h"
 #include "cef/libcef/browser/browser_host_base.h"
+#include "components/printing/common/print_dialog_linux_factory.h"
 #include "content/public/browser/browser_thread.h"
 #include "printing/buildflags/buildflags.h"
 #include "printing/print_dialog_linux_interface.h"
@@ -44,15 +45,19 @@ class CefPrintingContextLinuxDelegate
   raw_ptr<ui::PrintingContextLinuxDelegate> default_delegate_ = nullptr;
 };
 
-// Creates the Linux print dialog through CefPrintingContextLinuxDelegate so
-// that CefPrintHandler is used. Since M145 the dialog is created via a
+// Creates the Linux print dialog. When the associated browser provides a
+// CefPrintHandler the dialog is routed through CefPrintingContextLinuxDelegate
+// so that the handler is used; otherwise it falls back to the base
+// PrintDialogLinuxFactory implementation, preserving Chromium's default
+// (XDG portal / LinuxUi) dialog selection based on show_system_dialog and
+// settings. Since M145 the dialog is created via a
 // PrintingContextLinux::PrintDialogFactory whose default implementation
 // bypasses the delegate; this factory is registered in its place from
-// ChromeBrowserMainExtraPartsCef::ToolkitInitialized(). Out-of-process printing
-// must be disabled (--disable-features=EnableOopPrintDrivers) for the callbacks
-// to fire; see https://github.com/chromiumembedded/cef/issues/3729.
-class CefPrintDialogFactory
-    : public printing::PrintingContextLinux::PrintDialogFactory {
+// ChromeBrowserMainExtraPartsCef::ToolkitInitialized(). For browsers with a
+// CefPrintHandler, out-of-process printing must be disabled
+// (--disable-features=EnableOopPrintDrivers) for the callbacks to fire; see
+// https://github.com/chromiumembedded/cef/issues/3729.
+class CefPrintDialogFactory : public printing::PrintDialogLinuxFactory {
  public:
   CefPrintDialogFactory();
 

--- a/libcef/browser/printing/print_dialog_linux.h
+++ b/libcef/browser/printing/print_dialog_linux.h
@@ -44,7 +44,37 @@ class CefPrintingContextLinuxDelegate
   raw_ptr<ui::PrintingContextLinuxDelegate> default_delegate_ = nullptr;
 };
 
-// Needs to be freed on the UI thread to clean up its member variables.
+// Creates the Linux print dialog through CefPrintingContextLinuxDelegate so
+// that CefPrintHandler is used. Since M145 the dialog is created via a
+// PrintingContextLinux::PrintDialogFactory whose default implementation
+// bypasses the delegate; this factory is registered in its place from
+// ChromeBrowserMainExtraPartsCef::ToolkitInitialized(). Out-of-process printing
+// must be disabled (--disable-features=EnableOopPrintDrivers) for the callbacks
+// to fire; see https://github.com/chromiumembedded/cef/issues/3729.
+class CefPrintDialogFactory
+    : public printing::PrintingContextLinux::PrintDialogFactory {
+ public:
+  CefPrintDialogFactory();
+
+  CefPrintDialogFactory(const CefPrintDialogFactory&) = delete;
+  CefPrintDialogFactory& operator=(const CefPrintDialogFactory&) = delete;
+
+  // printing::PrintingContextLinux::PrintDialogFactory:
+  std::unique_ptr<printing::PrintDialogLinuxInterface> CreatePrintDialog(
+      printing::PrintingContextLinux* context,
+      bool show_system_dialog) override;
+#if BUILDFLAG(ENABLE_OOP_PRINTING_NO_OOP_BASIC_PRINT_DIALOG)
+  std::unique_ptr<printing::PrintDialogLinuxInterface>
+  CreatePrintDialogForSettings(
+      printing::PrintingContextLinux* context,
+      const printing::PrintSettings& settings) override;
+#endif
+};
+
+// Reference counted so that it can outlive the PrintingContextLinux that owns
+// it (via a std::unique_ptr<CefPrintDialogLinuxProxy>) until an asynchronous
+// print job driven by the client's CefPrintHandler completes. Freed on the UI
+// thread to clean up its member variables.
 class CefPrintDialogLinux : public printing::PrintDialogLinuxInterface,
                             public base::RefCountedThreadSafe<
                                 CefPrintDialogLinux,


### PR DESCRIPTION
Fixes #4130.

Summary:
- CefPrintHandler callbacks stopped firing on Linux in M145+ after upstream
  moved print dialog creation to a PrintingContextLinux::PrintDialogFactory
  whose default implementation bypasses CefPrintingContextLinuxDelegate.
- Register a CefPrintDialogFactory via the public
  PrintingContextLinux::SetPrintDialogFactory() so dialog creation routes back
  through the delegate and CefPrintHandler.
- Wrap the reference-counted CefPrintDialogLinux in a CefPrintDialogLinuxProxy
  owned by the context's unique_ptr; the proxy calls ReleaseDialog() on
  destruction so the dialog can outlive the PrintingContext until an async
  print job completes (M145 changed the dialog to be owned via unique_ptr).
- As with #3729, out-of-process printing must be disabled
  (--disable-features=EnableOopPrintDrivers) for the callbacks to fire.