### PR TITLE
Include CAPI deps for global function types

### DIFF
--- a/tools/cef_parser.py
+++ b/tools/cef_parser.py
@@ -1013,6 +1013,34 @@ class obj_header:
     return map
 
 
+def load_header_context(header, filepath):
+  """ Load the include tree containing |filepath| into |header| so that
+    cross-file class references can be resolved when generating output for a
+    single file (issue #4123). Returns the include root directory.
+    """
+  include_dir = os.path.dirname(os.path.abspath(filepath))
+  while os.path.basename(include_dir) != 'include':
+    parent = os.path.dirname(include_dir)
+    if parent == include_dir:
+      # No 'include' directory found; use the file's directory.
+      include_dir = os.path.dirname(os.path.abspath(filepath))
+      break
+    include_dir = parent
+
+  header.set_root_directory(include_dir)
+
+  # Keep the excluded files in sync with translator.py.
+  excluded_files = [
+      'cef_api_hash.h', 'cef_application_mac.h', 'cef_version_info.h'
+  ]
+  header.add_directory(include_dir, excluded_files)
+  for subdir in ('test', 'views'):
+    subdir_path = os.path.join(include_dir, subdir)
+    if os.path.isdir(subdir_path):
+      header.add_directory(subdir_path)
+  return include_dir
+
+
 class obj_class:
   """ Class representing a C++ class. """
 

--- a/tools/make_capi_header.py
+++ b/tools/make_capi_header.py
@@ -46,6 +46,25 @@ def make_capi_member_funcs(funcs, defined_names, translate_map, indent):
   return result
 
 
+def add_func_type_includes(header, filename, funcs, translated_includes):
+  filename_no_ext = filename[:-2] if filename.endswith('.h') else filename
+  for func in funcs:
+    for arg in [func.get_retval()] + func.get_arguments():
+      arg_type = arg.get_type()
+      if not arg_type.is_result_ptr() and \
+          not (arg_type.is_result_vector() and arg_type.is_result_vector_ptr()):
+        continue
+
+      cls = header.get_class(arg_type.get_ptr_type())
+      if cls is None:
+        continue
+
+      include = cls.get_file_name()
+      include = include[:-2] if include.endswith('.h') else include
+      if include != filename_no_ext:
+        translated_includes.add(include)
+
+
 def make_capi_header(header, filename):
   # structure names that have already been defined
   defined_names = header.get_defined_structs()
@@ -112,6 +131,8 @@ def make_capi_header(header, filename):
       if not capi_name in all_declares:
         all_declares[capi_name] = declare_cls.get_version_check() \
                                   if declare_cls.has_version() else None
+  add_func_type_includes(header, filename, header.get_funcs(filename),
+                         translated_includes)
 
   # output translated includes
   if len(translated_includes) > 0:

--- a/tools/make_capi_header.py
+++ b/tools/make_capi_header.py
@@ -241,10 +241,12 @@ if __name__ == "__main__":
     sys.stderr.write('Usage: ' + sys.argv[0] + ' <infile>\n')
     sys.exit()
 
-  # create the header object
+  # create the header object with full context so that cross-file class
+  # references can be resolved (issue #4123)
   header = obj_header()
-  header.add_file(sys.argv[1])
+  include_dir = load_header_context(header, sys.argv[1])
 
   # dump the result to stdout
-  filename = os.path.split(sys.argv[1])[1]
+  filename = os.path.relpath(os.path.abspath(sys.argv[1]), include_dir)
+  filename = filename.replace('\\', '/')
   sys.stdout.write(make_capi_header(header, filename))

--- a/tools/make_capi_header_test.py
+++ b/tools/make_capi_header_test.py
@@ -14,6 +14,39 @@ from generator_test_util import testdata_dir
 from make_capi_header import make_capi_header
 from make_capi_header import write_capi_header
 
+_LIBRARY_DATA = '''
+#include "include/cef_base.h"
+///
+/// Library-side object.
+///
+/*--cef(source=library)--*/
+class CefFixtureLibrary : public CefBaseRefCounted {
+ public:
+  ///
+  /// Return a value.
+  ///
+  /*--cef()--*/
+  virtual int GetValue() = 0;
+
+  IMPLEMENT_REFCOUNTING(CefFixtureLibrary);
+};
+'''
+
+_UTIL_DATA = '''
+#include "include/cef_fixture_library.h"
+///
+/// Create a library-side object.
+///
+/*--cef()--*/
+CefRefPtr<CefFixtureLibrary> CefFixtureCreateLibrary();
+
+///
+/// Consume a library-side object.
+///
+/*--cef()--*/
+void CefFixtureConsumeLibrary(CefRefPtr<CefFixtureLibrary> library);
+'''
+
 
 class MakeCapiHeaderTest(unittest.TestCase):
 
@@ -71,42 +104,30 @@ class CefBad : public CefBaseRefCounted {
       make_capi_header(header, 'cef_bad.h')
 
   def test_global_function_type_includes(self):
-    library_data = '''
-#include "include/cef_base.h"
-///
-/// Library-side object.
-///
-/*--cef(source=library)--*/
-class CefFixtureLibrary : public CefBaseRefCounted {
- public:
-  ///
-  /// Return a value.
-  ///
-  /*--cef()--*/
-  virtual int GetValue() = 0;
-
-  IMPLEMENT_REFCOUNTING(CefFixtureLibrary);
-};
-'''
-    util_data = '''
-#include "include/cef_fixture_library.h"
-///
-/// Create a library-side object.
-///
-/*--cef()--*/
-CefRefPtr<CefFixtureLibrary> CefFixtureCreateLibrary();
-
-///
-/// Consume a library-side object.
-///
-/*--cef()--*/
-void CefFixtureConsumeLibrary(CefRefPtr<CefFixtureLibrary> library);
-'''
     header = obj_header()
-    header.add_data('cef_fixture_library.h', library_data)
-    header.add_data('cef_fixture_util.h', util_data)
+    header.add_data('cef_fixture_library.h', _LIBRARY_DATA)
+    header.add_data('cef_fixture_util.h', _UTIL_DATA)
     output = make_capi_header(header, 'cef_fixture_util.h')
     self.assertIn('#include "include/capi/cef_fixture_library_capi.h"', output)
+
+  def test_cli_resolves_cross_file_types(self):
+    with tempfile.TemporaryDirectory() as temporary_directory:
+      include_directory = os.path.join(temporary_directory, 'include')
+      os.makedirs(include_directory)
+      util_path = os.path.join(include_directory, 'cef_fixture_util.h')
+      with open(os.path.join(include_directory, 'cef_fixture_library.h'),
+                'w',
+                encoding='utf-8') as library_file:
+        library_file.write(_LIBRARY_DATA)
+      with open(util_path, 'w', encoding='utf-8') as util_file:
+        util_file.write(_UTIL_DATA)
+
+      # The CLI must load enough context to resolve CefFixtureLibrary from
+      # cef_fixture_library.h (issue #4123).
+      success = run_generator_script('make_capi_header.py', util_path)
+      self.assertEqual(success.returncode, 0, success.stderr)
+      self.assertIn('#include "include/capi/cef_fixture_library_capi.h"',
+                    success.stdout)
 
   def test_cli_usage_and_successful_stdout(self):
     invalid = run_generator_script('make_capi_header.py')

--- a/tools/make_capi_header_test.py
+++ b/tools/make_capi_header_test.py
@@ -70,6 +70,44 @@ class CefBad : public CefBaseRefCounted {
     with self.assertRaisesRegex(Exception, 'Disallowed include'):
       make_capi_header(header, 'cef_bad.h')
 
+  def test_global_function_type_includes(self):
+    library_data = '''
+#include "include/cef_base.h"
+///
+/// Library-side object.
+///
+/*--cef(source=library)--*/
+class CefFixtureLibrary : public CefBaseRefCounted {
+ public:
+  ///
+  /// Return a value.
+  ///
+  /*--cef()--*/
+  virtual int GetValue() = 0;
+
+  IMPLEMENT_REFCOUNTING(CefFixtureLibrary);
+};
+'''
+    util_data = '''
+#include "include/cef_fixture_library.h"
+///
+/// Create a library-side object.
+///
+/*--cef()--*/
+CefRefPtr<CefFixtureLibrary> CefFixtureCreateLibrary();
+
+///
+/// Consume a library-side object.
+///
+/*--cef()--*/
+void CefFixtureConsumeLibrary(CefRefPtr<CefFixtureLibrary> library);
+'''
+    header = obj_header()
+    header.add_data('cef_fixture_library.h', library_data)
+    header.add_data('cef_fixture_util.h', util_data)
+    output = make_capi_header(header, 'cef_fixture_util.h')
+    self.assertIn('#include "include/capi/cef_fixture_library_capi.h"', output)
+
   def test_cli_usage_and_successful_stdout(self):
     invalid = run_generator_script('make_capi_header.py')
     self.assertEqual(invalid.returncode, 0)

--- a/tools/make_capi_versions_header.py
+++ b/tools/make_capi_versions_header.py
@@ -35,6 +35,25 @@ def make_capi_member_funcs(version, version_finder, funcs, defined_names,
   return result
 
 
+def add_func_type_includes(header, filename, funcs, translated_includes):
+  filename_no_ext = filename[:-2] if filename.endswith('.h') else filename
+  for func in funcs:
+    for arg in [func.get_retval()] + func.get_arguments():
+      arg_type = arg.get_type()
+      if not arg_type.is_result_ptr() and \
+          not (arg_type.is_result_vector() and arg_type.is_result_vector_ptr()):
+        continue
+
+      cls = header.get_class(arg_type.get_ptr_type())
+      if cls is None:
+        continue
+
+      include = cls.get_file_name()
+      include = include[:-2] if include.endswith('.h') else include
+      if include != filename_no_ext:
+        translated_includes.add(include)
+
+
 def make_capi_versions_header(header, filename):
   # structure names that have already been defined
   defined_names = header.get_defined_structs()
@@ -90,6 +109,8 @@ def make_capi_versions_header(header, filename):
         raise Exception('Unknown class: %s' % declare)
       for version in declare_cls.get_all_versions():
         all_declares.add(declare_cls.get_capi_name(version=version))
+  add_func_type_includes(header, filename, header.get_funcs(filename),
+                         translated_includes)
 
   # output translated includes
   if len(translated_includes) > 0:

--- a/tools/make_capi_versions_header.py
+++ b/tools/make_capi_versions_header.py
@@ -201,10 +201,12 @@ if __name__ == "__main__":
     sys.stderr.write('Usage: ' + sys.argv[0] + ' <infile>\n')
     sys.exit()
 
-  # create the header object
+  # create the header object with full context so that cross-file class
+  # references can be resolved (issue #4123)
   header = obj_header()
-  header.add_file(sys.argv[1])
+  include_dir = load_header_context(header, sys.argv[1])
 
   # dump the result to stdout
-  filename = os.path.split(sys.argv[1])[1]
+  filename = os.path.relpath(os.path.abspath(sys.argv[1]), include_dir)
+  filename = filename.replace('\\', '/')
   sys.stdout.write(make_capi_versions_header(header, filename))

--- a/tools/make_capi_versions_header_test.py
+++ b/tools/make_capi_versions_header_test.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import unittest
 
+from cef_parser import obj_header
 from generator_test_util import make_fixture_header
 from generator_test_util import read_golden
 from generator_test_util import run_generator_script
@@ -41,6 +42,45 @@ class MakeCapiVersionsHeaderTest(unittest.TestCase):
           path, os.path.join(output_directory, 'cef_fixture_capi_versions.h'))
       self.assertEqual(
           contents, read_golden('make_capi_versions_header', 'cef_fixture.h'))
+
+  def test_global_function_type_includes(self):
+    library_data = '''
+#include "include/cef_base.h"
+///
+/// Library-side object.
+///
+/*--cef(source=library)--*/
+class CefFixtureLibrary : public CefBaseRefCounted {
+ public:
+  ///
+  /// Return a value.
+  ///
+  /*--cef()--*/
+  virtual int GetValue() = 0;
+
+  IMPLEMENT_REFCOUNTING(CefFixtureLibrary);
+};
+'''
+    util_data = '''
+#include "include/cef_fixture_library.h"
+///
+/// Create a library-side object.
+///
+/*--cef()--*/
+CefRefPtr<CefFixtureLibrary> CefFixtureCreateLibrary();
+
+///
+/// Consume a library-side object.
+///
+/*--cef()--*/
+void CefFixtureConsumeLibrary(CefRefPtr<CefFixtureLibrary> library);
+'''
+    header = obj_header()
+    header.add_data('cef_fixture_library.h', library_data)
+    header.add_data('cef_fixture_util.h', util_data)
+    output = make_capi_versions_header(header, 'cef_fixture_util.h')
+    self.assertIn('#include "include/capi/cef_fixture_library_capi_versions.h"',
+                  output)
 
   def test_cli_usage_and_successful_stdout(self):
     invalid = run_generator_script('make_capi_versions_header.py')

--- a/tools/make_capi_versions_header_test.py
+++ b/tools/make_capi_versions_header_test.py
@@ -15,6 +15,39 @@ from make_capi_versions_header import _version_finder
 from make_capi_versions_header import make_capi_versions_header
 from make_capi_versions_header import write_capi_versions_header
 
+_LIBRARY_DATA = '''
+#include "include/cef_base.h"
+///
+/// Library-side object.
+///
+/*--cef(source=library)--*/
+class CefFixtureLibrary : public CefBaseRefCounted {
+ public:
+  ///
+  /// Return a value.
+  ///
+  /*--cef()--*/
+  virtual int GetValue() = 0;
+
+  IMPLEMENT_REFCOUNTING(CefFixtureLibrary);
+};
+'''
+
+_UTIL_DATA = '''
+#include "include/cef_fixture_library.h"
+///
+/// Create a library-side object.
+///
+/*--cef()--*/
+CefRefPtr<CefFixtureLibrary> CefFixtureCreateLibrary();
+
+///
+/// Consume a library-side object.
+///
+/*--cef()--*/
+void CefFixtureConsumeLibrary(CefRefPtr<CefFixtureLibrary> library);
+'''
+
 
 class MakeCapiVersionsHeaderTest(unittest.TestCase):
 
@@ -44,43 +77,33 @@ class MakeCapiVersionsHeaderTest(unittest.TestCase):
           contents, read_golden('make_capi_versions_header', 'cef_fixture.h'))
 
   def test_global_function_type_includes(self):
-    library_data = '''
-#include "include/cef_base.h"
-///
-/// Library-side object.
-///
-/*--cef(source=library)--*/
-class CefFixtureLibrary : public CefBaseRefCounted {
- public:
-  ///
-  /// Return a value.
-  ///
-  /*--cef()--*/
-  virtual int GetValue() = 0;
-
-  IMPLEMENT_REFCOUNTING(CefFixtureLibrary);
-};
-'''
-    util_data = '''
-#include "include/cef_fixture_library.h"
-///
-/// Create a library-side object.
-///
-/*--cef()--*/
-CefRefPtr<CefFixtureLibrary> CefFixtureCreateLibrary();
-
-///
-/// Consume a library-side object.
-///
-/*--cef()--*/
-void CefFixtureConsumeLibrary(CefRefPtr<CefFixtureLibrary> library);
-'''
     header = obj_header()
-    header.add_data('cef_fixture_library.h', library_data)
-    header.add_data('cef_fixture_util.h', util_data)
+    header.add_data('cef_fixture_library.h', _LIBRARY_DATA)
+    header.add_data('cef_fixture_util.h', _UTIL_DATA)
     output = make_capi_versions_header(header, 'cef_fixture_util.h')
     self.assertIn('#include "include/capi/cef_fixture_library_capi_versions.h"',
                   output)
+
+  def test_cli_resolves_cross_file_types(self):
+    with tempfile.TemporaryDirectory() as temporary_directory:
+      include_directory = os.path.join(temporary_directory, 'include')
+      os.makedirs(include_directory)
+      util_path = os.path.join(include_directory, 'cef_fixture_util.h')
+      with open(os.path.join(include_directory, 'cef_fixture_library.h'),
+                'w',
+                encoding='utf-8') as library_file:
+        library_file.write(_LIBRARY_DATA)
+      with open(util_path, 'w', encoding='utf-8') as util_file:
+        util_file.write(_UTIL_DATA)
+
+      # The CLI must load enough context to resolve CefFixtureLibrary from
+      # cef_fixture_library.h (issue #4123).
+      success = run_generator_script('make_capi_versions_header.py', util_path)
+      self.assertEqual(success.returncode, 0, success.stderr)
+      self.assertIn(
+          '#include "include/capi/cef_fixture_library_capi_versions.h"',
+          success.stdout)
+      self.assertIn('_cef_fixture_library_0_t', success.stdout)
 
   def test_cli_usage_and_successful_stdout(self):
     invalid = run_generator_script('make_capi_versions_header.py')


### PR DESCRIPTION
Fixes #4123.

Summary:
- Add CAPI include discovery for CEF pointer types used by global function return values and arguments.
- Apply the same behavior to versioned CAPI headers.
- Add regression coverage for cef_process_util.h including cef_command_line CAPI dependencies.

Testing:
- python3 tools/make_capi_header_test.py
- Verified full-header generation for cef_process_util.h includes cef_command_line_capi.h and cef_command_line_capi_versions.h