### PR TITLE
Fix remaining BrowserWidget::OnTouchUiChanged crash (fixes #3941)

### DIFF
--- a/patch/patches/chrome_runtime_views.patch
+++ b/patch/patches/chrome_runtime_views.patch
@@ -601,10 +601,12 @@ index 582e4ccaf8879d938761aabf0d09668b30875a49..06c524a0b5feeb2bba17cb6780750ca2
    // Ignore the system theme for web apps with window-controls-overlay as the
    // display_override so the web contents can blend with the overlay by using
    // the developer-provided theme color for a better experience. Context:
-@@ -515,15 +544,17 @@ void BrowserWidget::SelectNativeTheme() {
- void BrowserWidget::OnTouchUiChanged() {
-   client_view()->InvalidateLayout();
+@@ -513,17 +542,23 @@ void BrowserWidget::SelectNativeTheme() {
+ }
  
+ void BrowserWidget::OnTouchUiChanged() {
+-  client_view()->InvalidateLayout();
+-
 -  // For standard browser frame, if we do not invalidate the FrameView
 -  // the client window bounds will not be properly updated which could cause
 -  // visual artifacts. See crbug.com/40112464 for details.
@@ -614,6 +616,12 @@ index 582e4ccaf8879d938761aabf0d09668b30875a49..06c524a0b5feeb2bba17cb6780750ca2
 -    non_client_view()->frame_view()->InvalidateLayout();
 -  } else {
 -    non_client_view()->InvalidateLayout();
++  // client_view() is null when there is no NonClientView (e.g. CEF Chrome-style
++  // browsers with a native parent use TYPE_CONTROL). See CEF issue #3941.
++  if (client_view()) {
++    client_view()->InvalidateLayout();
++  }
++
 +  if (non_client_view()) {
 +    // For standard browser frame, if we do not invalidate the FrameView
 +    // the client window bounds will not be properly updated which could cause
@@ -628,7 +636,7 @@ index 582e4ccaf8879d938761aabf0d09668b30875a49..06c524a0b5feeb2bba17cb6780750ca2
    }
    GetRootView()->InvalidateLayout();
  }
-@@ -564,5 +595,8 @@ bool BrowserWidget::RegenerateFrameOnThemeChange(
+@@ -564,5 +599,8 @@ bool BrowserWidget::RegenerateFrameOnThemeChange(
  }
  
  bool BrowserWidget::IsIncognitoBrowser() const {


### PR DESCRIPTION
Chrome-style browsers with a native parent use TYPE_CONTROL widgets, which have no NonClientView, so client_view() returns nullptr. Guard that InvalidateLayout call; the earlier non_client_view() check alone was insufficient.