### PR TITLE
linux: Add support for embedded Ozone/Wayland windows

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -340,6 +340,10 @@ group("cef") {
   if (!is_linux || ozone_platform_x11) {
     deps += [ ":cefclient" ]
   }
+
+  if (is_linux && ozone_platform_wayland) {
+    deps += [ ":cefembed_wayland" ]
+  }
 }
 
 
@@ -2722,6 +2726,40 @@ if (is_mac) {
   #
   # cefsimple targets.
   #
+
+  #
+  # cefembed_wayland target.
+  #
+
+  # Minimal Wayland client that embeds a browser in its own window. cefclient's
+  # Linux windowing path is GTK over X11 and hands CEF an XID, so this is the
+  # only sample that exercises the three-argument CefWindowInfo::SetAsChild().
+  if (is_linux && ozone_platform_wayland) {
+    executable("cefembed_wayland") {
+      # Necessary because the libcef target is testonly.
+      testonly = true
+
+      sources = [
+        "tests/cefembed_wayland/main.cc",
+      ]
+
+      deps = [
+        ":libcef",
+        ":libcef_dll_wrapper",
+        "//third_party/wayland:wayland_client",
+        "//third_party/wayland-protocols:cursor_shape_protocol",
+
+        # Not used directly. cursor-shape-v1 references zwp_tablet_tool_v2 in
+        # its own interface table, so dropping this fails the link with
+        # "undefined symbol: zwp_tablet_tool_v2_interface".
+        "//third_party/wayland-protocols:tablet_protocol",
+        "//third_party/wayland-protocols:xdg_shell_protocol",
+      ]
+
+      # Disable clang modules for this target (see issue #3611).
+      use_libcxx_modules = false
+    }
+  }
 
   executable("cefsimple") {
     # Necessary because the libcef target is testonly.

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -415,6 +415,10 @@ source_set("libcef_static_unittested") {
     "libcef/browser/devtools/devtools_util.h",
     "libcef/browser/geometry_util.h",
     "libcef/browser/geometry_util.cc",
+
+    # CefStructBase copies string members through these, so anything testing a
+    # struct's copy semantics needs them linked in.
+    "libcef/common/string_types_impl.cc",
   ]
 
   deps = [
@@ -441,6 +445,10 @@ test("libcef_static_unittests") {
     "libcef/browser/devtools/devtools_util_unittest.cc",
     "libcef/browser/geometry_util_unittest.cc",
   ]
+
+  if (is_linux) {
+    sources += [ "libcef/browser/native/window_info_linux_unittest.cc" ]
+  }
 
   deps = [
     ":libcef_static_unittested",
@@ -1067,6 +1075,9 @@ source_set("libcef_static") {
     sources += includes_linux + [
       "libcef/browser/native/browser_platform_delegate_native_linux.cc",
       "libcef/browser/native/browser_platform_delegate_native_linux.h",
+      "libcef/browser/native/ozone_util_linux.cc",
+      "libcef/browser/native/ozone_util_linux.h",
+      "libcef/browser/native/wayland_util_linux.cc",
       "libcef/browser/osr/browser_platform_delegate_osr_linux.cc",
       "libcef/browser/osr/browser_platform_delegate_osr_linux.h",
       "libcef/browser/printing/print_dialog_linux.cc",

--- a/docs/wayland_embedding.md
+++ b/docs/wayland_embedding.md
@@ -1,0 +1,240 @@
+This page describes the design for embedding CEF browser windows inside Wayland windows owned by a client application, and tracks the state of the implementation on this branch.
+
+Upstream issue: [#2804 — Linux: Add support for embedded Ozone/Wayland windows](https://github.com/chromiumembedded/cef/issues/2804)
+
+**Contents**
+
+- [Problem](#problem)
+- [Why X11 embedding does not translate](#why-x11-embedding-does-not-translate)
+- [Design](#design)
+- [Public API](#public-api)
+- [Connection adoption](#connection-adoption)
+- [The embedded window](#the-embedded-window)
+- [Input](#input)
+- [Popups](#popups)
+- [What cannot be preserved](#what-cannot-be-preserved)
+- [Implementation status](#implementation-status)
+
+---
+
+# Problem
+
+CEF has three ways to host web content:
+
+| Mode | Entry point | Wayland |
+|---|---|---|
+| Views | `CefBrowserView` + `CefWindow` | works |
+| Windowless | `CefWindowInfo::SetAsWindowless` | works |
+| Native windowed | `CefWindowInfo::SetAsChild` | **missing** |
+
+Native windowed is the mode where the client application owns a native window and CEF creates a child window inside it. It is what OBS uses for browser docks in its own UI and, most likely, what the Steam client uses. On Linux it is implemented entirely by `CefWindowX11`, and there is no Wayland counterpart.
+
+Before this branch, `CreateHostWindow()` selected that implementation on `BUILDFLAG(SUPPORTS_OZONE_X11)` alone. Because release binaries compile in both Ozone platforms, the X11 path also ran under Ozone/Wayland and produced either a stray XWayland window or nothing at all, followed by a crash in `WaylandWindowManager::GetWindow()` on the first event dispatch. That is fixed separately; this document is about supplying the missing mode.
+
+# Why X11 embedding does not translate
+
+An X11 `Window` is a 32-bit id allocated by the X server. It is global: any client, on any connection, in any process, can reference another client's window given only the number. `CefWindowX11` relies on this. It opens its own X connection through `x11::Connection::Get()` and still parents its window inside the client application's window, because `parent` in `x11::Connection::CreateWindow()` is just an integer.
+
+A `wl_surface` is a protocol object bound to one `wl_display` connection. It is not an integer, not serializable, and does not cross a connection boundary — not even between two `wl_display`s inside the same process. `wl_subcompositor_get_subsurface()` requires the parent and child surfaces to belong to the same connection.
+
+Everything below follows from that one fact.
+
+# Design
+
+## Public API
+
+The parent surface is not a new field. `cef_window_info_t::parent_window` has always been an opaque native parent handle whose meaning depends on the platform — it is an `HWND` on Windows and an `NSView*` on macOS — so under Ozone/Wayland it names a `wl_surface`. The `unsigned long` spelling on Linux is an artifact of X11, and it holds a pointer on LP64. Existing embedders keep compiling and keep working.
+
+The cost of that choice is the failure mode: an X11 Window passed while Wayland is active is dereferenced as a pointer. A valid XID such as `0x2600004` is numerically indistinguishable from an address, so this cannot be diagnosed, only documented. In practice the handle comes from the client's toolkit, which knows which platform it is on.
+
+One member is appended to `cef_window_info_t`, guarded by `CEF_API_ADDED(CEF_EXPERIMENTAL)` so existing stable API versions keep their ABI:
+
+```c
+cef_xdg_surface_handle_t parent_xdg_surface;  // in, for popups
+```
+
+with a three-argument `CefWindowInfo::SetAsChild(parent, parent_xdg, bounds)` overload alongside the existing two-argument form. It may be null: toolkits differ in whether they expose the `xdg_surface` at all — winit does not — and refusing to create the browser would put embedding out of reach for those hosts. Without it the browser renders and takes input, and popups fall back to a degraded `wl_subsurface` form described under [Popups](#popups).
+
+Appending is only half of ABI safety. `CefWindowInfoTraits::set()` copies the new member under `CEF_MEMBER_EXISTS`, because `size` is what distinguishes a smaller struct from a larger one at runtime; the `#if` alone is a compile-time test and would read past the end of an older client's allocation.
+
+An earlier revision also returned the browser's own `wl_surface` as an output member. It was removed: a `wl_surface` is scoped to the connection that created it, which the embedder already owns, so the handle told the embedder nothing it could act on, while costing struct size and public API surface. What comes back in `cef_window_info_t::window` is a `gfx::AcceleratedWidget` — an id internal to the process, not a protocol object, unlike the X11 `Window` that field carries under Ozone/X11.
+
+**The Ozone platform has to be selected explicitly.** Ozone picks X11 wherever `DISPLAY` is set, which under a Wayland session means XWayland, and then `parent_window` — a `wl_surface*` — is read as an X11 `Window`. That is the undefined-rather-than-diagnosed failure described above, reached without the embedder doing anything wrong. Pass `--ozone-platform=wayland` on the command line CEF receives rather than through `CefSettings`: subprocesses inherit `argv`, and they have to agree with the browser process about the platform.
+
+`CefBrowserHost::SetWindowBounds()` is declared last in the class on purpose. The translator moves versioned members to the end of the generated C struct in declaration order, so putting it anywhere earlier would shift the existing experimental `set_ax_viewport_collapse` and silently break callers compiled against it.
+
+The connection is *not* passed per browser. Chromium builds its `WaylandConnection` while initializing Ozone, which happens inside `CefInitialize`, long before any `CefWindowInfo` exists. Adoption is therefore a process-global, one-time decision, exposed separately:
+
+```c
+CEF_EXPORT void cef_set_wayland_display(cef_wayland_display_handle_t display);
+CEF_EXPORT cef_wayland_display_handle_t cef_get_wayland_display(void);
+```
+
+`cef_set_wayland_display()` must be called before `CefInitialize`. The 2020 Igalia prototype put a `wayland_display_handle` on `CefWindowInfo`; that cannot work, because by the time a `CefWindowInfo` is available the connection has already been made.
+
+The client passes its own connection because CEF has to join it. This is the inverse of the X11 contract, where CEF opens its own connection and the client passes only a window id.
+
+## Connection adoption
+
+`ui::WaylandConnection::Initialize()` calls `wl_display_connect()` unconditionally. It needs to accept an externally owned `wl_display*` instead.
+
+Two event loops then share one connection, which libwayland does not support naively: whichever side calls `wl_display_dispatch()` first consumes the other side's events. The supported mechanism is:
+
+* create a dedicated `wl_event_queue` for Chromium via `wl_display_create_queue()`;
+* wrap every proxy Chromium creates with `wl_proxy_create_wrapper()` and assign it to that queue with `wl_proxy_set_queue()`, so that events for Chromium's objects are delivered to Chromium's queue;
+* dispatch with `wl_display_dispatch_queue()` instead of `wl_display_dispatch()`;
+* never call `wl_display_disconnect()` on an adopted connection.
+
+Ownership rules for the adopted case:
+
+* the client owns the connection and must outlive every browser using it;
+* CEF must not roundtrip on the default queue, because the client may be blocked in its own dispatch;
+* `wl_display_flush()` is shared and safe.
+
+## The embedded window
+
+`gfx::AcceleratedWidget` on Ozone/Wayland is not a `wl_surface`. It is an opaque id that `WaylandWindowManager` maps to a `WaylandWindow`. Any code that receives a widget — screen scale lookup, event dispatch, occlusion — goes through that map. So the embedded window cannot be synthesized from a foreign handle; it has to be a real `WaylandWindow` that registers itself.
+
+The new window type:
+
+* is created from `PlatformWindowInitProperties` carrying the client's parent `wl_surface`;
+* creates its own `wl_surface` and turns it into a subsurface of the parent via `wl_subcompositor_get_subsurface()`;
+* positions itself with `wl_subsurface_set_position()` using the requested bounds, relative to the parent surface origin;
+* uses desynchronized mode (`wl_subsurface_set_desync()`) so that browser frames are not gated on the client committing its parent surface;
+* registers with `WaylandWindowManager` like any other `WaylandWindow`, which is what makes widget lookup work and is precisely what was crashing before.
+
+There is no CEF-side counterpart of `CefWindowX11`, and there does not need to be. `CefWindowX11` exists because `DesktopWindowTreeHostLinux` cannot be reparented into a foreign X11 window, so CEF interposes a window of its own between the two. On Wayland the embedded window *is* the `DesktopWindowTreeHostLinux`'s platform window, so CEF only has to name the parent surface and let views build the rest.
+
+Naming it is the trick. views has no vocabulary for a native parent other than `gfx::AcceleratedWidget`, and `DesktopWindowTreeHostLinux` already forwards `views::Widget::InitParams::parent_widget` into `PlatformWindowInitProperties`. Registering the client's `wl_surface` with `WaylandWindowManager` yields such a widget, so nothing in views changes.
+
+One trap: `WaylandWindow::Create()` cannot decide this from `PlatformWindowType`. views maps every `Widget::InitParams::Type` it does not recognise to `kPopup`, and `TYPE_CONTROL` -- which is what an embedded browser uses -- is one of those. The foreign-parent check therefore runs before the type switch.
+
+## Input
+
+Pointer input works: `wl_pointer.enter` is delivered per surface, and a subsurface is a surface, so it receives pointer events normally.
+
+Keyboard is more interesting. `wl_keyboard.enter` is delivered only to the surface that holds the seat's keyboard focus, and a `wl_subsurface` never holds it — the client's toplevel does. There is no protocol mechanism for a subsurface to take keyboard focus.
+
+Issue #2804 concluded from this that every embedder would have to intercept `wl_keyboard` and replay events through `CefBrowserHost::SendKeyEvent`. That turns out not to be necessary. Chromium is already on the client's connection and already receives those events; it was discarding them because `RootWindowFromWlSurface()` could not resolve the client's toplevel to any window it knew. Teaching that lookup about registered foreign surfaces routes keyboard focus to the embedded window, and typing works with no embedder code at all.
+
+The same lookup closes a memory-safety hole. It reads a `wl_surface`'s user data and casts it to `ui::WaylandSurface`; on a surface owned by the embedder that pointer belongs to their toolkit. Nothing crashed only because the sample never sets user data — GTK and Qt both do.
+
+Splitting the lookup is also what makes drag and drop attribute correctly, which was not obvious in advance. The embedder and Chromium each create a `wl_data_device` from the same `wl_seat` on the same connection, and both receive `wl_data_device.enter` for a drag anywhere over the window; nothing in the protocol arbitrates between them. What decides is the `wl_surface` the event carries. Because `RootWindowFromWlSurface()` resolves only Chromium's own surfaces and returns null for the embedder's, Chromium ignores drags over the host's chrome and claims the ones over the browser's subsurface, while the host does the reverse. Had the keyboard fallback been left in the shared lookup, a drag over the host's own UI would have resolved to the embedded browser and been delivered twice.
+
+Text input goes the same way, and is routed the same way: `zwp_text_input_v3` is per seat and follows the focused surface, so its enter/leave name the embedder's toplevel and resolve through the same lookup as the keyboard.
+
+What that does *not* buy is correctness across a focus change. Those protocol events fire once and are not repeated when the host moves between two browsers inside one window, so `Activate()` has to move the recorded text-input focus itself, alongside the keyboard focus. And routing alone is not enough either: `Activate()` must also reach `PlatformWindowDelegate::OnActivationChanged()`, because the composition state lives on the views side and `InputMethod::OnFocus`/`OnBlur` are delivered from there. An earlier revision of this branch moved the Ozone-level focus without notifying the delegate, which would have left the IME attached to whichever browser was focused first.
+
+Verified end to end with ibus and Intelligent Pinyin: preedit renders underlined inside the field, the candidate window is placed next to the caret rather than at the surface origin, and the commit lands in the input. The candidate window placement was the part expected to break, since it is positioned from `set_cursor_rectangle` coordinates and the window they describe is a subsurface; it turns out correct, because those coordinates are computed against the same window whose bounds the embedder supplies.
+
+Dead keys are not evidence for any of this. xkbcommon composes them inside Chromium from the keymap, with `zwp_text_input_v3` uninvolved, so they work whether or not text input is routed at all.
+
+## Popups
+
+`xdg_popup` requires an `xdg_surface` as its parent. A `wl_subsurface` has no `xdg_surface` role, so context menus, `<select>` dropdowns, tooltips, autocomplete and date pickers have nothing to anchor to.
+
+There is no protocol that fixes this, and it is worth being precise about why, because two mechanisms look like they might. `xdg_surface.get_popup` does accept a null parent — but only "if a parent surface is specified using some other protocol", and that protocol is `xdg_foreign`, whose `zxdg_imported_v2.set_parent_of` rejects anything that is not "an xdg_toplevel equivalent". Neither reaches a subsurface.
+
+Two options remain, both lossy:
+
+**(a) Anchor on the client's toplevel.** The client passes its `xdg_surface` alongside the parent `wl_surface`. CEF creates popups as children of it and measures anchor rectangles in that surface's coordinates. Positioning depends on the client keeping CEF's idea of the embedded bounds current through `CefBrowserHost::SetWindowBounds()`; a stale value puts menus in the wrong place.
+
+**(b) Emulate popups with more subsurfaces.** Loses pointer grab, loses click-outside dismissal, loses `xdg_positioner` edge flipping, and clips the popup to the client window bounds.
+
+This branch implements (a) wherever it can, because (b) is not really a menu. What makes (a) workable is that the embedder and CEF share one connection, so the embedder's `xdg_surface` is simply an object that can be handed over.
+
+(b) is nonetheless implemented too, as the fallback for an embedder that has no `xdg_surface` to hand over — winit is one. The alternative would be to fail, and failing is not available: `WaylandWindow::Create()` returning null makes views destroy the widget inside `Widget::Show()`, and `Widget::HandleWidgetDestroyed()` `CHECK`s on exactly that. The choice is not between a good menu and no menu; it is between a degraded menu and an aborted process.
+
+The degradation is real and worth stating plainly: a dropdown near the bottom edge of the host window is clipped rather than flipped, and clicking outside it does not dismiss it. `cef_window_info_t::parent_xdg_surface` documents this, and both CEF and Ozone log a warning naming the limitation when the fallback is taken. An embedder whose toolkit exposes the `xdg_surface` should always pass it.
+
+# What cannot be preserved
+
+`CefWindowX11` carries thirteen responsibilities. Seven have no Wayland equivalent:
+
+| X11 | Wayland | Disposition |
+|---|---|---|
+| parent at creation | `wl_subcompositor_get_subsurface` | works, same connection required |
+| `WM_CLIENT_MACHINE`, `_NET_WM_PID`, title | — | gone, no functional loss |
+| size hints + map | subsurface + parent commit | works |
+| `XdndProxy` | `wl_data_device` | works; the drag is attributed by the `wl_surface` the enter event carries, so no proxying is needed |
+| `Focus()` | — | blocked by protocol, becomes client's job |
+| `Close()` via `WM_DELETE_WINDOW` | — | becomes client's job |
+| `SetBounds()` | `wl_subsurface_set_position` | works |
+| `GetBoundsInScreen()` | — | impossible by design, no global coordinates |
+| `ConfigureNotify` | `xdg_toplevel.configure` on the client | becomes client's job |
+| `_NET_WM_PING` | — | gone |
+| `FocusIn`/`FocusOut` | — | blocked by protocol |
+| `_NET_WM_STATE` min/max | `xdg_toplevel` states on the client | becomes client's job |
+| `TopLevelAlwaysOnTop()` | — | not queryable |
+
+The pattern: on X11 CEF observes the window system passively. On Wayland the client has to push that state in. That is why this cannot be a drop-in replacement, and why embedders will need code changes even after it lands.
+
+# Implementation status
+
+| # | Item | Where | State |
+|---|---|---|---|
+| 1 | Runtime Ozone platform selection; fail cleanly instead of crashing | CEF | **done** |
+| 2 | Keyboard translation stops using X11 keysyms under other platforms | CEF | **done** |
+| 3 | `parent_window` carries a `wl_surface`; `parent_xdg_surface`, `cef_set_wayland_display` | CEF | **done** |
+| 4 | `WaylandConnection` adopts an external `wl_display` | Chromium patch | **done** |
+| 5 | `WaylandEmbeddedWindow` + foreign-surface registry | Chromium patch | **done** |
+| 6 | `CreateHostWindow()`/`CloseHostWindow()` build and tear down the embedded window | CEF | **done** |
+| 7 | Popups anchored on the embedder's `xdg_surface` | Chromium patch | **done** |
+| 8 | Keyboard focus routed to the embedded window | Chromium patch | **done** |
+| 9 | `CefBrowserHost::SetWindowBounds()` for host-driven geometry | CEF | **done** |
+| 10 | Sample exercising all of it (`tests/cefembed_wayland`) | CEF | **done** |
+| 11 | IME: `zwp_text_input_v3` routed and focus moved with the browser | Chromium patch | **done** |
+| 12 | Drag and drop into and out of the embedded surface | Chromium patch | **done** |
+| 13 | HiDPI and fractional scale | Chromium patch + embedder | **done** |
+| 14 | `cefclient` gains a Wayland windowing path (today it is GTK over X11) | CEF | not started |
+
+Items 4, 5, 7, 8 and 11 live in `patch/patches/ozone_wayland_embed_2804.patch` rather than in CEF source, because they are changes to Chromium. That patch is why this cannot be done in CEF alone.
+
+Item 14 is the only one left, and it is not about embedding: `cefclient`'s Linux windowing path is GTK over X11 and hands CEF an XID (`GDK_WINDOW_XID` in `root_window_gtk.cc` and `browser_window_std_gtk.cc`, plus `temp_window_x11.cc`), so there is nothing there to pass a `wl_surface` through. That is why the sample in `tests/cefembed_wayland` exists at all.
+
+Item 13 is listed against the embedder as well as the patch, because half of it is a contract rather than code. Ozone tracks *changes* on its own: the embedded window's surface receives `wl_surface.enter`/`leave` and binds `wp_fractional_scale_v1` like any other, so `WaylandWindow::UpdateWindowScale()` follows a move between outputs and the browser renders sharp at the new scale without the embedder doing anything.
+
+The initial value is the part that needed work, because there is no change to observe. A window with a parent inherits the parent's scale; `WaylandWindow::Initialize()` takes `state->window_scale` as final and does not call `UpdateWindowScale()` afterwards. An embedded window has no parent, so a browser created while the host already sits on a fractional output would render at the primary display's scale and stay blurry until dragged to another output and back -- only then does an event arrive. It seeds itself from a sibling already embedded in the same surface instead, which is on the same output by construction; the primary display remains the fallback when there is no sibling.
+
+What the embedder does have to get right is the units it passes to `CefBrowserHost::SetWindowBounds()`. Those are DIP, because they end up in `wl_subsurface.set_position`, which is surface-local. A client whose own layout is in device pixels must divide by its scale factor first. The two are equal at scale 1, so an embedder that gets this wrong sees nothing until the window meets a fractional-scale output, at which point the browser is displaced by the scale factor and can leave the screen entirely.
+
+## Verification status
+
+Run on Fedora 44, GNOME 49 Wayland, against a local build of this branch (Chromium 151.0.7922.0), driving `tests/cefembed_wayland` by hand.
+
+| Claim | Status |
+|---|---|
+| Ozone/Wayland compiles with the patch | yes |
+| API additions break no existing API hash | yes — `2 hashes checked and match`, `116 patches total (0 failed)` |
+| The client's connection is adopted | yes — Chromium's surface takes protocol id 50 on the connection whose host surface is id 3; a separate connection would have restarted at 1 |
+| Web content renders inside the client's window | yes |
+| Pointer input reaches the browser | yes |
+| `<select>` dropdowns open, correctly positioned | yes |
+| Context menus open | yes |
+| Keyboard input reaches the browser | yes, with no embedder involvement |
+| Resizing tracks the host's layout | yes, driven by `CefBrowserHost::SetWindowBounds()` |
+| The X11 path still works | yes, unchanged behaviour with the same binary |
+| Closing the browser completes | yes |
+| IME / composition | yes — ibus with Intelligent Pinyin: underlined preedit inside the field, candidate window correctly placed next to the caret, commit lands in the input. Identical in the embedded, X11 and Views paths |
+| Drag and drop | yes — files dropped into the browser, and text and files dragged out of it to other applications, with drops over the host's own chrome still going to the host |
+| HiDPI / fractional scale | yes — starting on either kind of output and dragging between a 1x and a fractional-scale one, in both directions: correct position, sharp rendering. Scale changes while a popup is open remain untested |
+| Multiple embedded browsers in one window | yes — created, moved, hidden, closed independently, and keyboard focus follows both `SetFocus()` and a click |
+
+Known rough edge: during an interactive resize the browser's contents lag the window frame by a frame or so. `wl_subsurface.set_position` is double-buffered on the *parent* surface, so a move only lands when the embedder commits, and the two surfaces are submitted in separate compositor frames with no atomicity between them. `WaylandBubble` carries the same TODO upstream (crbug.com/329145822). Fixing it needs explicit synchronisation, not a change here.
+
+### ANGLE-Wayland is not involved
+
+Worth recording because the assumption is widespread: this works without the ANGLE Wayland backend. The ANGLE in this checkout has only `renderer/vulkan/linux/wayland/WindowSurfaceVkWayland`, the Vulkan path that predates it; `renderer/gl/egl/` contains no Wayland backend at all.
+
+In the default multi-process configuration the GPU process has no `WaylandConnection`. It renders into GBM/dmabuf and the browser process presents through `zwp_linux_dmabuf_v1`, which is what the connection actually binds. `EGL_PLATFORM_WAYLAND_EXT` is never reached. The ANGLE Wayland backend only matters for `--single-process`/`--in-process-gpu` or embedded targets with no DRM render node.
+
+### Traps found while bringing this up
+
+Recorded because each cost real time and none is obvious from the code.
+
+* **`WAYLAND_DEBUG=1` shows none of Chromium's requests.** The client and libcef each link their own static copy of libwayland, and the debug flag is initialised inside `wl_display_connect()`. Only the client calls it. Use logging inside Ozone instead.
+* **`Widget::InitParams::TYPE_CONTROL` becomes `PlatformWindowType::kPopup`.** views maps every type it does not recognise to `kPopup`, so an embedded browser never arrives as `kWindow`. Selecting the embedded window type from `properties.type` silently produces a separate toplevel instead.
+* **A wl_subsurface has no close protocol.** `CloseHostWindow()` must close the `views::Widget` directly. Waiting for a window-manager close, the way the X11 path does, hangs `CloseBrowser()` forever and leaves a live browser for `CefShutdown()` to destroy the connection underneath.
+* **GNOME does not advertise `zxdg_decoration_manager_v1`.** An embedder gets no titlebar, no close button and no resize grips unless it draws and drives them itself, and no cursor at all unless it sets one.
+* **Partial `wl_pointer_listener` initialisers abort the process.** libwayland calls every slot the negotiated version implies.
+* **A client that configures a Stable API version cannot see any of this.** `cef_api_hash()` decides which struct layout libcef publishes. Under 15101 `cef_browser_host_t` ends at `get_runtime_style` and every `CEF_API_ADDED(CEF_EXPERIMENTAL)` member is absent, so `SetWindowBounds()` is simply not there -- 584 bytes published against the 600 a caller expecting it would compute. That is the versioning system working correctly, but it means an embedder must opt into the experimental API to use any of this before it is assigned a version.

--- a/include/cef_browser.h
+++ b/include/cef_browser.h
@@ -1089,6 +1089,33 @@ class CefBrowserHost : public virtual CefBaseRefCounted {
   /*--cef(added=experimental)--*/
   virtual void SetAxViewportCollapse(bool enabled) = 0;
 #endif
+
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+  ///
+  /// Set the position and size of a windowed browser, relative to the parent
+  /// window that was passed to CefWindowInfo. Only used on Linux.
+  ///
+  /// On X11 the browser observes the parent window and resizes itself, so this
+  /// is not needed. On Wayland there is no such signal: a wl_subsurface does
+  /// not receive configure events, which are delivered to the client's
+  /// xdg_toplevel instead. The client application must therefore forward its
+  /// own layout changes here.
+  ///
+  /// |bounds| is in density-independent pixels, not device pixels. The values
+  /// reach wl_subsurface.set_position, which is surface-local to the client's
+  /// surface and therefore in the same logical units the compositor uses for
+  /// that surface. A client that keeps its layout in device pixels must divide
+  /// by its scale factor before calling this; the two are identical at scale 1,
+  /// so getting it wrong is invisible until the window meets a HiDPI or
+  /// fractional-scale output, where the browser lands offset by the scale.
+  ///
+  /// Note that wl_subsurface.set_position is part of the parent surface's
+  /// double-buffered state, so the move only becomes visible when the client
+  /// next commits its own surface.
+  ///
+  /*--cef(added=experimental)--*/
+  virtual void SetWindowBounds(const CefRect& bounds) = 0;
+#endif
 };
 
 #endif  // CEF_INCLUDE_CEF_BROWSER_H_

--- a/include/internal/cef_linux.h
+++ b/include/internal/cef_linux.h
@@ -38,6 +38,10 @@
 #define CefCursorHandle cef_cursor_handle_t
 #define CefEventHandle cef_event_handle_t
 #define CefWindowHandle cef_window_handle_t
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+#define CefWaylandDisplayHandle cef_wayland_display_handle_t
+#define CefXdgSurfaceHandle cef_xdg_surface_handle_t
+#endif
 
 ///
 /// Class representing CefExecuteProcess arguments.
@@ -71,6 +75,21 @@ struct CefWindowInfoTraits {
     target->external_begin_frame_enabled = src->external_begin_frame_enabled;
     target->window = src->window;
     target->runtime_style = src->runtime_style;
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+    // |src| comes from the client and may have been compiled against an older,
+    // smaller struct. Reading the member without this check is a read past the
+    // end of that allocation.
+    //
+    // The else matters as much as the check. CefStructBase::Set() calls
+    // Clear() first to "clear newer members that won't be set", but clear()
+    // only frees string members; a stale pointer here would otherwise survive
+    // being assigned over from an older client's struct.
+    if (CEF_MEMBER_EXISTS(src, parent_xdg_surface)) {
+      target->parent_xdg_surface = src->parent_xdg_surface;
+    } else {
+      target->parent_xdg_surface = nullptr;
+    }
+#endif
   }
 };
 
@@ -90,6 +109,36 @@ class CefWindowInfo : public CefStructBase<CefWindowInfoTraits> {
     parent_window = parent;
     this->bounds = bounds;
   }
+
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+  ///
+  /// Create the browser as a child window, additionally naming the client's
+  /// xdg_surface when the active Ozone platform is Wayland.
+  ///
+  /// |parent| is the same opaque native parent handle the two-argument
+  /// overload takes: an X11 Window under Ozone/X11, a struct wl_surface* cast
+  /// to CefWindowHandle under Ozone/Wayland. A Wayland surface must belong to
+  /// the connection previously passed to cef_set_wayland_display(), which must
+  /// be called before CefInitialize, because wl_surface objects cannot be
+  /// shared across connections. See
+  /// https://github.com/chromiumembedded/cef/issues/2804.
+  ///
+  /// |parent_xdg| is the xdg_surface that |parent| belongs to. It is what the
+  /// browser's menus, <select> dropdowns and tooltips are anchored on, since a
+  /// wl_subsurface cannot be an xdg_popup parent. Passing NULL still leaves the
+  /// browser able to render and take input, with popups falling back to a
+  /// degraded wl_subsurface form; see cef_window_info_t::parent_xdg_surface.
+  /// It is ignored under X11, where the two-argument overload is all that is
+  /// needed.
+  ///
+  void SetAsChild(CefWindowHandle parent,
+                  CefXdgSurfaceHandle parent_xdg,
+                  const CefRect& bounds) {
+    parent_window = parent;
+    parent_xdg_surface = parent_xdg;
+    this->bounds = bounds;
+  }
+#endif
 
   ///
   /// Create the browser using windowless (off-screen) rendering. No window

--- a/include/internal/cef_types_linux.h
+++ b/include/internal/cef_types_linux.h
@@ -37,6 +37,7 @@
 
 #if defined(OS_LINUX)
 
+#include "include/cef_api_hash.h"
 #include "include/internal/cef_export.h"
 #include "include/internal/cef_string.h"
 #include "include/internal/cef_types_color.h"
@@ -47,6 +48,11 @@
 #define kNullCursorHandle 0
 #define kNullEventHandle NULL
 #define kNullWindowHandle 0
+
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+#define kNullWaylandDisplayHandle NULL
+#define kNullXdgSurfaceHandle NULL
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,12 +72,58 @@ typedef void* cef_event_handle_t;
 
 typedef unsigned long cef_window_handle_t;
 
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+
+///
+/// Handle type for a Wayland connection (struct wl_display*).
+///
+typedef void* cef_wayland_display_handle_t;
+
+///
+/// Handle type for an xdg_surface (struct xdg_surface*).
+///
+typedef void* cef_xdg_surface_handle_t;
+#endif
+
 ///
 /// Return the singleton X11 display shared with Chromium. The display is not
 /// thread-safe and must only be accessed on the browser process UI thread.
 ///
 #if defined(CEF_X11)
 CEF_EXPORT XDisplay* cef_get_xdisplay(void);
+#endif
+
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+///
+/// Give CEF the Wayland connection (struct wl_display*) owned by the client
+/// application, so that browser surfaces can be created as subsurfaces of the
+/// client's surfaces. A wl_surface is a protocol object scoped to one
+/// connection and wl_subcompositor_get_subsurface() requires both surfaces to
+/// belong to the same one, so embedding is only possible if CEF joins the
+/// client's connection instead of opening its own.
+///
+/// Must be called before CefInitialize. Chromium creates its Wayland connection
+/// while initializing Ozone, which happens during CefInitialize and long before
+/// any browser exists, so this is necessarily a process-global, one-time
+/// decision rather than a per-browser one.
+///
+/// The client retains ownership and must keep the connection alive until after
+/// CefShutdown. CEF dispatches its own protocol traffic on a dedicated
+/// wl_event_queue and never calls wl_display_disconnect() on an adopted
+/// connection, so the client may keep running its own event loop on the
+/// default queue.
+///
+/// Has no effect if the active Ozone platform is not Wayland.
+///
+CEF_EXPORT void cef_set_wayland_display(cef_wayland_display_handle_t display);
+
+///
+/// Return the Wayland connection used by Chromium, or NULL if the active Ozone
+/// platform is not Wayland. If the client provided a connection via
+/// cef_set_wayland_display() then that same connection is returned. Must only
+/// be accessed on the browser process UI thread.
+///
+CEF_EXPORT cef_wayland_display_handle_t cef_get_wayland_display(void);
 #endif
 
 ///
@@ -109,6 +161,19 @@ typedef struct _cef_window_info_t {
   ///
   /// Pointer for the parent window.
   ///
+  /// When the active Ozone platform is Wayland this is a struct wl_surface*
+  /// belonging to the client application, cast to cef_window_handle_t; the
+  /// browser surface becomes a wl_subsurface of it. Under X11 it is an X11
+  /// Window, as before. The field has always been an opaque native parent
+  /// handle whose meaning depends on the platform -- it is an NSView* on
+  /// macOS and an HWND on Windows -- and Wayland is no different; the
+  /// unsigned long spelling here is an artifact of X11.
+  ///
+  /// A Wayland surface must belong to the connection previously passed to
+  /// cef_set_wayland_display(). Note that CEF cannot tell a mistaken X11
+  /// Window from a valid pointer, so passing the wrong kind of handle for the
+  /// active platform is undefined rather than diagnosed.
+  ///
   cef_window_handle_t parent_window;
 
   ///
@@ -141,6 +206,15 @@ typedef struct _cef_window_info_t {
   ///
   /// Pointer for the new browser window. Only used with windowed rendering.
   ///
+  /// Under Ozone/X11 this is the X11 Window of the browser, usable from any
+  /// client on the connection. Under Ozone/Wayland it is not a protocol object
+  /// at all: it is the gfx::AcceleratedWidget Ozone uses internally, an id
+  /// meaningful only inside this process. A wl_surface cannot be handed back
+  /// this way because it is scoped to the connection that created it, so an
+  /// embedder that needs to address the browser's surface should keep the
+  /// parent surface it passed in and position the browser through
+  /// CefBrowserHost::SetWindowBounds() instead.
+  ///
   cef_window_handle_t window;
 
   ///
@@ -149,6 +223,30 @@ typedef struct _cef_window_info_t {
   /// documentation for details.
   ///
   cef_runtime_style_t runtime_style;
+
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+  ///
+  /// The client application's xdg_surface (struct xdg_surface*), the one
+  /// |parent_window| belongs to when it names a wl_surface.
+  ///
+  /// Required for the browser to open menus, <select> dropdowns, tooltips and
+  /// autocomplete. A wl_subsurface has no xdg_surface role, and
+  /// xdg_surface.get_popup demands an xdg_surface, so popups from an embedded
+  /// browser have to be anchored on the client's instead. Their positions are
+  /// then computed in the client's surface coordinates.
+  ///
+  /// May be NULL for hosts whose toolkit does not expose the xdg_surface. The
+  /// browser then renders and takes input as usual, and popups fall back to a
+  /// wl_subsurface of the browser. That fallback is degraded and deliberately
+  /// so: a subsurface cannot extend past the host window, so a dropdown near an
+  /// edge is clipped rather than repositioned, and it holds no grab, so
+  /// clicking outside does not dismiss it. Provide the xdg_surface wherever the
+  /// toolkit allows it.
+  ///
+  /// Ignored unless the active Ozone platform is Wayland.
+  ///
+  cef_xdg_surface_handle_t parent_xdg_surface;
+#endif
 } cef_window_info_t;
 
 ///

--- a/libcef/browser/browser_host_base.cc
+++ b/libcef/browser/browser_host_base.cc
@@ -895,6 +895,25 @@ bool CefBrowserHostBase::IsAudioMuted() {
   return false;
 }
 
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+void CefBrowserHostBase::SetWindowBounds(const CefRect& bounds) {
+  if (!CEF_CURRENTLY_ON_UIT()) {
+    CEF_POST_TASK(CEF_UIT, base::BindOnce(&CefBrowserHostBase::SetWindowBounds,
+                                          this, bounds));
+    return;
+  }
+
+#if BUILDFLAG(IS_WIN) || (BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_MAC))
+  // SetHostBounds() only exists on the platforms where a windowed browser can
+  // be repositioned inside a parent window; see CefBrowserPlatformDelegate.
+  if (platform_delegate_) {
+    platform_delegate_->SetHostBounds(
+        gfx::Rect(bounds.x, bounds.y, bounds.width, bounds.height));
+  }
+#endif
+}
+#endif
+
 void CefBrowserHostBase::NotifyMoveOrResizeStarted() {
 #if BUILDFLAG(IS_WIN) || (BUILDFLAG(IS_POSIX) && !BUILDFLAG(IS_MAC))
   if (!CEF_CURRENTLY_ON_UIT()) {

--- a/libcef/browser/browser_host_base.h
+++ b/libcef/browser/browser_host_base.h
@@ -274,6 +274,9 @@ class CefBrowserHostBase : public CefBrowserHost,
   void SetAudioMuted(bool mute) override;
   bool IsAudioMuted() override;
   void NotifyMoveOrResizeStarted() override;
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+  void SetWindowBounds(const CefRect& bounds) override;
+#endif
   void NotifyScreenInfoChanged() override;
   bool IsFullscreen() override;
   void ExitFullscreen(bool will_cause_resize) override;

--- a/libcef/browser/browser_platform_delegate.cc
+++ b/libcef/browser/browser_platform_delegate.cc
@@ -331,6 +331,8 @@ void CefBrowserPlatformDelegate::SendCaptureLostEvent() {
 void CefBrowserPlatformDelegate::NotifyMoveOrResizeStarted() {}
 
 void CefBrowserPlatformDelegate::SizeTo(int width, int height) {}
+
+void CefBrowserPlatformDelegate::SetHostBounds(const gfx::Rect& bounds) {}
 #endif
 
 gfx::Point CefBrowserPlatformDelegate::GetScreenPoint(

--- a/libcef/browser/browser_platform_delegate.h
+++ b/libcef/browser/browser_platform_delegate.h
@@ -252,6 +252,11 @@ class CefBrowserPlatformDelegate {
   // Resize the host window to the given dimensions. Only used with windowed
   // rendering on Windows and Linux.
   virtual void SizeTo(int width, int height);
+
+  // Move and resize a windowed browser within its parent window. Only
+  // meaningful on platforms where the browser cannot observe the parent window
+  // itself; see CefBrowserHost::SetWindowBounds.
+  virtual void SetHostBounds(const gfx::Rect& bounds);
 #endif
 
   // Convert from view DIP coordinates to screen coordinates. If

--- a/libcef/browser/native/browser_platform_delegate_native_linux.cc
+++ b/libcef/browser/native/browser_platform_delegate_native_linux.cc
@@ -5,14 +5,18 @@
 #include "cef/libcef/browser/native/browser_platform_delegate_native_linux.h"
 
 #include "base/no_destructor.h"
+#include "cef/libcef/browser/alloy/alloy_browser_host_impl.h"
 #include "cef/libcef/browser/browser_host_base.h"
 #include "cef/libcef/browser/context.h"
 #include "cef/libcef/browser/native/native_widget_delegate.h"
+#include "cef/libcef/browser/native/ozone_util_linux.h"
 #include "cef/libcef/browser/thread_util.h"
 #include "components/input/native_web_keyboard_event.h"
 #include "content/browser/renderer_host/render_widget_host_impl.h"
 #include "content/public/browser/render_view_host.h"
 #include "third_party/blink/public/mojom/renderer_preferences.mojom.h"
+#include "ui/aura/window.h"
+#include "ui/aura/window_tree_host.h"
 #include "ui/events/keycodes/dom/dom_key.h"
 #include "ui/events/keycodes/dom/keycode_converter.h"
 #include "ui/events/keycodes/keysym_to_unicode.h"
@@ -26,6 +30,10 @@
 #include "ui/views/widget/desktop_aura/desktop_window_tree_host_linux.h"
 #endif
 
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+#include "ui/ozone/platform/wayland/wayland_embedder.h"
+#endif
+
 CefBrowserPlatformDelegateNativeLinux::CefBrowserPlatformDelegateNativeLinux(
     const CefWindowInfo& window_info,
     SkColor background_color)
@@ -35,6 +43,13 @@ void CefBrowserPlatformDelegateNativeLinux::BrowserDestroyed(
     CefBrowserHostBase* browser) {
   CefBrowserPlatformDelegateNativeAura::BrowserDestroyed(browser);
 
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+  if (wayland_parent_widget_ != gfx::kNullAcceleratedWidget) {
+    ui::UnregisterForeignWaylandSurface(wayland_parent_widget_);
+    wayland_parent_widget_ = gfx::kNullAcceleratedWidget;
+  }
+#endif
+
   if (host_window_created_) {
     // Release the reference added in CreateHostWindow().
     browser->Release();
@@ -43,6 +58,28 @@ void CefBrowserPlatformDelegateNativeLinux::BrowserDestroyed(
 
 bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
   DCHECK(!window_widget_);
+
+  // A single libcef binary is typically built with both the X11 and Wayland
+  // Ozone platforms compiled in, so BUILDFLAG(SUPPORTS_OZONE_X11) only tells us
+  // that the X11 code exists -- not that it is usable. Creating a CefWindowX11
+  // while Ozone/Wayland is active produces an X11 (or XWayland) window that is
+  // not parented to the client's wl_surface, and then feeds its XID to
+  // CefNativeWidgetDelegate::Init() as a gfx::AcceleratedWidget. Ozone/Wayland
+  // resolves accelerated widgets through WaylandWindowManager, which has never
+  // heard of that value, and the first event dispatch crashes in
+  // WaylandScreen::GetPreferredScaleFactorForAcceleratedWidget().
+  //
+  // Fail explicitly instead. See
+  // https://github.com/chromiumembedded/cef/issues/2804.
+  if (!cef_ozone::SupportsNativeWindowedBrowsers()) {
+    LOG(ERROR) << "Windowed browsers are not supported on the \""
+               << cef_ozone::PlatformName()
+               << "\" Ozone platform. Use windowless rendering "
+                  "(CefWindowInfo::SetAsWindowless) or the Views framework "
+                  "(CefBrowserView) instead. See "
+                  "https://github.com/chromiumembedded/cef/issues/2804";
+    return false;
+  }
 
   if (window_info_.bounds.width == 0) {
     window_info_.bounds.width = 800;
@@ -54,39 +91,49 @@ bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
   gfx::Rect rect(window_info_.bounds.x, window_info_.bounds.y,
                  window_info_.bounds.width, window_info_.bounds.height);
 
-#if BUILDFLAG(SUPPORTS_OZONE_X11)
-  DCHECK(!window_x11_);
-
-  x11::Window parent_window = x11::Window::None;
-  if (window_info_.parent_window != kNullWindowHandle) {
-    parent_window = static_cast<x11::Window>(window_info_.parent_window);
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+  if (cef_ozone::IsWayland()) {
+    if (!CreateWaylandHostWindow(rect)) {
+      return false;
+    }
   }
+#endif  // BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
 
-  // Create a new window object. It will delete itself when the associated X11
-  // window is destroyed.
-  window_x11_ =
-      new CefWindowX11(browser_.get(), parent_window, rect,
-                       CefString(&window_info_.window_name).ToString());
-  DCHECK_NE(window_x11_->xwindow(), x11::Window::None);
-  window_info_.window =
-      static_cast<cef_window_handle_t>(window_x11_->xwindow());
+#if BUILDFLAG(SUPPORTS_OZONE_X11)
+  if (cef_ozone::IsX11()) {
+    DCHECK(!window_x11_);
 
-  host_window_created_ = true;
+    x11::Window parent_window = x11::Window::None;
+    if (window_info_.parent_window != kNullWindowHandle) {
+      parent_window = static_cast<x11::Window>(window_info_.parent_window);
+    }
 
-  // Add a reference that will be released in BrowserDestroyed().
-  browser_->AddRef();
+    // Create a new window object. It will delete itself when the associated X11
+    // window is destroyed.
+    window_x11_ =
+        new CefWindowX11(browser_.get(), parent_window, rect,
+                         CefString(&window_info_.window_name).ToString());
+    DCHECK_NE(window_x11_->xwindow(), x11::Window::None);
+    window_info_.window =
+        static_cast<cef_window_handle_t>(window_x11_->xwindow());
 
-  auto* widget_delegate = new CefNativeWidgetDelegate(
-      GetBackgroundColor(), window_x11_->TopLevelAlwaysOnTop(),
-      GetBoundsChangedCallback(), GetWidgetDeleteCallback());
-  widget_delegate->Init(
-      static_cast<gfx::AcceleratedWidget>(window_info_.window), web_contents_,
-      gfx::Rect(gfx::Point(), rect.size()));
+    host_window_created_ = true;
 
-  window_widget_ = widget_delegate->GetWidget();
-  window_widget_->Show();
+    // Add a reference that will be released in BrowserDestroyed().
+    browser_->AddRef();
 
-  window_x11_->Show();
+    auto* widget_delegate = new CefNativeWidgetDelegate(
+        GetBackgroundColor(), window_x11_->TopLevelAlwaysOnTop(),
+        GetBoundsChangedCallback(), GetWidgetDeleteCallback());
+    widget_delegate->Init(
+        static_cast<gfx::AcceleratedWidget>(window_info_.window), web_contents_,
+        gfx::Rect(gfx::Point(), rect.size()));
+
+    window_widget_ = widget_delegate->GetWidget();
+    window_widget_->Show();
+
+    window_x11_->Show();
+  }
 #endif  // BUILDFLAG(SUPPORTS_OZONE_X11)
 
   // As an additional requirement on Linux, we must set the colors for the
@@ -114,12 +161,138 @@ bool CefBrowserPlatformDelegateNativeLinux::CreateHostWindow() {
   return true;
 }
 
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+bool CefBrowserPlatformDelegateNativeLinux::CreateWaylandHostWindow(
+    const gfx::Rect& rect) {
+  // Under Ozone/Wayland parent_window names a wl_surface rather than an X11
+  // Window. There is no way to tell a mistaken XID from a valid pointer, so a
+  // client that passes the wrong kind of handle for the active platform gets
+  // undefined behaviour rather than a diagnostic; all that can be checked is
+  // that something was passed at all.
+  auto* parent_surface =
+      reinterpret_cast<wl_surface*>(window_info_.parent_window);
+  if (!parent_surface) {
+    LOG(ERROR) << "A windowed browser on Wayland needs the client's wl_surface "
+                  "in CefWindowInfo::parent_window; it is null";
+    return false;
+  }
+  // |parent_xdg_surface| is deliberately not required. Toolkits differ in
+  // whether they expose the xdg_surface at all -- winit, for one, does not --
+  // and refusing to create the browser would put embedding out of reach for
+  // those hosts entirely. Menus then fall back to a wl_subsurface, which is
+  // degraded but usable; see the warning below and cef_types_linux.h.
+  LOG_IF(WARNING, !window_info_.parent_xdg_surface)
+      << "No xdg_surface was provided in CefWindowInfo::parent_xdg_surface; "
+         "menus, tooltips and <select> dropdowns will fall back to a "
+         "wl_subsurface, which cannot extend past this window or be dismissed "
+         "by clicking outside it";
+
+  if (!ui::GetExternalWaylandDisplay()) {
+    LOG(ERROR) << "cef_set_wayland_display() must be called before "
+                  "CefInitialize() to embed a browser into a Wayland surface; "
+                  "a wl_surface cannot be shared across connections";
+    return false;
+  }
+
+  // Name the client's surface with a gfx::AcceleratedWidget so that it can
+  // travel through views::Widget::InitParams::parent_widget, which is the only
+  // way views knows how to express a parent. WaylandWindow::Create() resolves
+  // it back into the surface and builds a WaylandEmbeddedWindow.
+  wayland_parent_widget_ = ui::RegisterForeignWaylandSurface(
+      parent_surface,
+      static_cast<xdg_surface*>(window_info_.parent_xdg_surface));
+  if (wayland_parent_widget_ == gfx::kNullAcceleratedWidget) {
+    LOG(ERROR) << "Failed to register the parent wl_surface with Ozone";
+    return false;
+  }
+
+  auto* widget_delegate = new CefNativeWidgetDelegate(
+      GetBackgroundColor(), /*always_on_top=*/false, GetBoundsChangedCallback(),
+      // The widget going away is what completes the browser teardown here, the
+      // way WM_NCDESTROY does on Windows and CefWindowX11 does on X11. Without
+      // it CloseBrowser() never finishes.
+      base::BindOnce(
+          &CefBrowserPlatformDelegateNativeLinux::WaylandWidgetDeleted,
+          linux_weak_factory_.GetWeakPtr(), GetWidgetDeleteCallback()));
+  widget_delegate->Init(wayland_parent_widget_, web_contents_, rect);
+
+  window_widget_ = widget_delegate->GetWidget();
+
+  // Report back what was created. Unlike X11, |window| is not a server-global
+  // id here: it is the gfx::AcceleratedWidget that Ozone uses internally, and
+  // it is only meaningful inside this process.
+  wl_surface* surface = nullptr;
+  if (auto* window = window_widget_->GetNativeWindow()) {
+    if (auto* host = window->GetHost()) {
+      const gfx::AcceleratedWidget widget = host->GetAcceleratedWidget();
+      window_info_.window = static_cast<cef_window_handle_t>(widget);
+      surface = ui::GetWaylandSurfaceForWidget(widget);
+    }
+  }
+
+  // Everything that can fail has to fail before the two lines below. They are
+  // undone by BrowserDestroyed(), which is not called for a browser that never
+  // finished being created, so a later bail-out would leak the reference and
+  // leave the client's surface registered forever.
+  if (!surface) {
+    LOG(ERROR) << "The browser window was created but has no wl_surface";
+    window_widget_->CloseNow();
+    window_widget_ = nullptr;
+    ui::UnregisterForeignWaylandSurface(wayland_parent_widget_);
+    wayland_parent_widget_ = gfx::kNullAcceleratedWidget;
+    return false;
+  }
+
+  host_window_created_ = true;
+
+  // Add a reference that will be released in BrowserDestroyed().
+  browser_->AddRef();
+
+  window_widget_->Show();
+
+  VLOG(1) << "Embedded browser surface " << surface << " into parent surface "
+          << parent_surface;
+  return true;
+}
+
+void CefBrowserPlatformDelegateNativeLinux::WaylandWidgetDeleted(
+    base::OnceClosure clear_widget) {
+  std::move(clear_widget).Run();
+
+  // Only meaningful once the host window was fully created. A widget torn down
+  // by a failed CreateWaylandHostWindow() has no reference to release and no
+  // browser to destroy; the Windows path guards the same case by checking
+  // |browser| for null.
+  if (host_window_created_ && browser_) {
+    // Force the browser to be destroyed. This results in a call to
+    // BrowserDestroyed() that releases the reference added above.
+    AlloyBrowserHostImpl::FromBaseChecked(browser_.get())->WindowDestroyed();
+  }
+}
+#endif  // BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+
 void CefBrowserPlatformDelegateNativeLinux::CloseHostWindow() {
 #if BUILDFLAG(SUPPORTS_OZONE_X11)
   if (window_x11_) {
     window_x11_->Close();
+    return;
   }
 #endif
+
+  // On X11 the close travels through the window manager: CefWindowX11 sends
+  // itself WM_DELETE_WINDOW and destroys the browser when it comes back.
+  // Wayland has no equivalent for a wl_subsurface -- xdg_toplevel.close does
+  // not apply, and the compositor has nothing to close -- so the widget has to
+  // be closed directly. Without this CloseBrowser() never completes; it waits
+  // for a host window teardown that nothing will ever signal, and a later
+  // CefShutdown() then destroys WaylandConnection underneath a browser that is
+  // still alive.
+  // IsClosed() because CloseBrowser() can arrive more than once -- a second
+  // Close() on a widget already tearing down would run the delete callback
+  // twice, and with it WindowDestroyed().
+  if (window_widget_ && !window_widget_->IsClosed()) {
+    window_widget_->Close();
+  }
 }
 
 CefWindowHandle CefBrowserPlatformDelegateNativeLinux::GetHostWindowHandle()
@@ -135,6 +308,21 @@ views::Widget* CefBrowserPlatformDelegateNativeLinux::GetWindowWidget() const {
 }
 
 void CefBrowserPlatformDelegateNativeLinux::SetFocus(bool setFocus) {
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+  // Handled ahead of the early return below, which predates embedding: under
+  // X11 the window manager takes focus away by itself, so blur needed nothing
+  // here. An embedded browser has no window the compositor knows about, and
+  // both directions have to be driven explicitly -- otherwise a host with two
+  // browsers can ask for focus but never give it up.
+  if (cef_ozone::IsWayland() && window_widget_) {
+    if (setFocus) {
+      window_widget_->Activate();
+    } else {
+      window_widget_->Deactivate();
+    }
+  }
+#endif  // BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+
   if (!setFocus) {
     return;
   }
@@ -151,8 +339,10 @@ void CefBrowserPlatformDelegateNativeLinux::SetFocus(bool setFocus) {
     // Needs to be done via the ::Window so that keyboard focus is assigned
     // correctly.
     window_x11_->Focus();
+    return;
   }
 #endif  // BUILDFLAG(SUPPORTS_OZONE_X11)
+
 }
 
 void CefBrowserPlatformDelegateNativeLinux::NotifyMoveOrResizeStarted() {
@@ -193,6 +383,24 @@ void CefBrowserPlatformDelegateNativeLinux::SizeTo(int width, int height) {
         gfx::Rect(window_x11_->bounds().origin(), gfx::Size(width, height)));
   }
 #endif  // BUILDFLAG(SUPPORTS_OZONE_X11)
+}
+
+void CefBrowserPlatformDelegateNativeLinux::SetHostBounds(
+    const gfx::Rect& bounds) {
+#if BUILDFLAG(SUPPORTS_OZONE_X11)
+  if (window_x11_) {
+    window_x11_->SetBounds(bounds);
+    return;
+  }
+#endif
+
+  // On Wayland the browser's wl_subsurface receives no configure events, so the
+  // client application is the only source of layout information. Route it
+  // through the Widget, which reaches WaylandEmbeddedWindow::SetBoundsInDIP()
+  // and hence wl_subsurface.set_position.
+  if (window_widget_) {
+    window_widget_->SetBounds(bounds);
+  }
 }
 
 void CefBrowserPlatformDelegateNativeLinux::ViewText(const std::string& text) {
@@ -249,12 +457,18 @@ ui::KeyEvent CefBrowserPlatformDelegateNativeLinux::TranslateUiKeyEvent(
   ui::DomCode dom_code =
       ui::KeycodeConverter::NativeKeycodeToDomCode(key_event.native_key_code);
 
-#if BUILDFLAG(SUPPORTS_OZONE_X11)
-  int keysym = ui::XKeysymForWindowsKeyCode(
-      key_code, !!(key_event.modifiers & EVENTFLAG_SHIFT_DOWN));
-  char16_t character = ui::GetUnicodeCharacterFromXKeySym(keysym);
-#else
+  // The X11 keysym tables are only meaningful when Ozone/X11 is active. Under
+  // any other Ozone platform the client-supplied character is authoritative.
   char16_t character = key_event.character;
+  bool have_keysym = false;
+  int keysym = 0;
+#if BUILDFLAG(SUPPORTS_OZONE_X11)
+  if (cef_ozone::IsX11()) {
+    keysym = ui::XKeysymForWindowsKeyCode(
+        key_code, !!(key_event.modifiers & EVENTFLAG_SHIFT_DOWN));
+    character = ui::GetUnicodeCharacterFromXKeySym(keysym);
+    have_keysym = true;
+  }
 #endif
 
   base::TimeTicks time_stamp = GetEventTimeStamp();
@@ -277,11 +491,15 @@ ui::KeyEvent CefBrowserPlatformDelegateNativeLinux::TranslateUiKeyEvent(
       DCHECK(false);
   }
 
-#if BUILDFLAG(SUPPORTS_OZONE_X11)
-  ui::DomKey dom_key = ui::XKeySymToDomKey(keysym, character);
-#else
   ui::DomKey dom_key = ui::DomKey::NONE;
+#if BUILDFLAG(SUPPORTS_OZONE_X11)
+  if (have_keysym) {
+    dom_key = ui::XKeySymToDomKey(keysym, character);
+  }
 #endif
+  if (dom_key == ui::DomKey::NONE && character != 0) {
+    dom_key = ui::DomKey::FromCharacter(character);
+  }
 
   return ui::KeyEvent(type, key_code, dom_code, flags, dom_key, time_stamp);
 }

--- a/libcef/browser/native/browser_platform_delegate_native_linux.h
+++ b/libcef/browser/native/browser_platform_delegate_native_linux.h
@@ -8,6 +8,11 @@
 #include "base/memory/raw_ptr.h"
 #include "cef/libcef/browser/native/browser_platform_delegate_native_aura.h"
 #include "ui/base/ozone_buildflags.h"
+#include "ui/gfx/native_ui_types.h"
+
+namespace gfx {
+class Rect;
+}
 
 #if BUILDFLAG(SUPPORTS_OZONE_X11)
 class CefWindowX11;
@@ -29,6 +34,7 @@ class CefBrowserPlatformDelegateNativeLinux
   void SetFocus(bool setFocus) override;
   void NotifyMoveOrResizeStarted() override;
   void SizeTo(int width, int height) override;
+  void SetHostBounds(const gfx::Rect& bounds) override;
   void ViewText(const std::string& text) override;
   bool HandleKeyboardEvent(const input::NativeWebKeyboardEvent& event) override;
   CefEventHandle GetEventHandle(
@@ -40,12 +46,33 @@ class CefBrowserPlatformDelegateNativeLinux
       const CefKeyEvent& key_event) const override;
 
  private:
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+  // Creates the browser window as a wl_subsurface of the client's surface,
+  // which must have been provided via the three-argument
+  // CefWindowInfo::SetAsChild().
+  bool CreateWaylandHostWindow(const gfx::Rect& rect);
+
+  // Runs |clear_widget| and then completes the browser teardown. Bound as the
+  // widget delete callback because on Wayland nothing else signals that the
+  // host window is gone.
+  void WaylandWidgetDeleted(base::OnceClosure clear_widget);
+#endif
+
   // True if the host window has been created.
   bool host_window_created_ = false;
 
 #if BUILDFLAG(SUPPORTS_OZONE_X11)
   raw_ptr<CefWindowX11> window_x11_ = nullptr;
 #endif
+
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+  // Names the client's wl_surface for the duration of the browser. Released in
+  // BrowserDestroyed().
+  gfx::AcceleratedWidget wayland_parent_widget_ = gfx::kNullAcceleratedWidget;
+#endif
+
+  base::WeakPtrFactory<CefBrowserPlatformDelegateNativeLinux> linux_weak_factory_{
+      this};
 };
 
 #endif  // CEF_LIBCEF_BROWSER_NATIVE_BROWSER_PLATFORM_DELEGATE_NATIVE_LINUX_H_

--- a/libcef/browser/native/ozone_util_linux.cc
+++ b/libcef/browser/native/ozone_util_linux.cc
@@ -1,0 +1,41 @@
+// Copyright 2026 The Chromium Embedded Framework Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cef/libcef/browser/native/ozone_util_linux.h"
+
+#include "ui/base/ozone_buildflags.h"
+#include "ui/ozone/platform_selection.h"
+
+namespace cef_ozone {
+
+std::string_view PlatformName() {
+  // ui::GetOzonePlatformName() reports the platform actually selected for this
+  // process, unlike the SUPPORTS_OZONE_* build flags, which only say what was
+  // compiled in. DesktopWindowTreeHostLinux::AddAdditionalInitProperties()
+  // consults the same function.
+  const char* name = ui::GetOzonePlatformName();
+  return name ? std::string_view(name) : std::string_view();
+}
+
+bool IsX11() {
+#if BUILDFLAG(SUPPORTS_OZONE_X11)
+  return PlatformName() == "x11";
+#else
+  return false;
+#endif
+}
+
+bool IsWayland() {
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+  return PlatformName() == "wayland";
+#else
+  return false;
+#endif
+}
+
+bool SupportsNativeWindowedBrowsers() {
+  return IsX11() || IsWayland();
+}
+
+}  // namespace cef_ozone

--- a/libcef/browser/native/ozone_util_linux.h
+++ b/libcef/browser/native/ozone_util_linux.h
@@ -1,0 +1,33 @@
+// Copyright 2026 The Chromium Embedded Framework Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CEF_LIBCEF_BROWSER_NATIVE_OZONE_UTIL_LINUX_H_
+#define CEF_LIBCEF_BROWSER_NATIVE_OZONE_UTIL_LINUX_H_
+#pragma once
+
+#include <string_view>
+
+namespace cef_ozone {
+
+// Name of the Ozone platform that was selected at runtime ("x11", "wayland",
+// "headless", ...). A single libcef binary may be built with multiple Ozone
+// platforms compiled in, so build flags alone are not sufficient to determine
+// which windowing code path is valid. Must be called after Ozone has been
+// initialized.
+std::string_view PlatformName();
+
+// True if the active Ozone platform is X11.
+bool IsX11();
+
+// True if the active Ozone platform is Wayland.
+bool IsWayland();
+
+// True if the active Ozone platform can host a browser window inside a native
+// window owned by the client application (CefWindowInfo::SetAsChild on X11,
+// the three-argument SetAsChild on Wayland).
+bool SupportsNativeWindowedBrowsers();
+
+}  // namespace cef_ozone
+
+#endif  // CEF_LIBCEF_BROWSER_NATIVE_OZONE_UTIL_LINUX_H_

--- a/libcef/browser/native/wayland_util_linux.cc
+++ b/libcef/browser/native/wayland_util_linux.cc
@@ -1,0 +1,35 @@
+// Copyright 2026 The Chromium Embedded Framework Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/logging.h"
+#include "cef/include/internal/cef_types_linux.h"
+#include "cef/libcef/browser/context.h"
+#include "ui/base/ozone_buildflags.h"
+
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+#include "ui/ozone/platform/wayland/wayland_embedder.h"
+#endif
+
+CEF_EXPORT void cef_set_wayland_display(cef_wayland_display_handle_t display) {
+  if (CONTEXT_STATE_VALID()) {
+    LOG(ERROR) << "cef_set_wayland_display() must be called before "
+                  "CefInitialize(); Chromium creates its Wayland connection "
+                  "while initializing Ozone";
+    return;
+  }
+
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+  // Ozone only reads this when it starts up, which happens inside
+  // CefInitialize, so recording it now is both necessary and sufficient.
+  ui::SetExternalWaylandDisplay(static_cast<wl_display*>(display));
+#endif
+}
+
+CEF_EXPORT cef_wayland_display_handle_t cef_get_wayland_display() {
+#if BUILDFLAG(SUPPORTS_OZONE_WAYLAND)
+  return ui::GetWaylandDisplay();
+#else
+  return nullptr;
+#endif
+}

--- a/libcef/browser/native/window_info_linux_unittest.cc
+++ b/libcef/browser/native/window_info_linux_unittest.cc
@@ -1,0 +1,131 @@
+// Copyright 2026 The Chromium Embedded Framework Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <cstring>
+#include <vector>
+
+#include "cef/include/cef_base.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// The Wayland embedding work appended |parent_xdg_surface| to
+// cef_window_info_t under CEF_API_ADDED(CEF_EXPERIMENTAL). Appending keeps the
+// offsets of every older member, but that is only half of ABI safety: an
+// application built against a smaller struct passes a smaller allocation, and
+// |size| is the only thing that says so at runtime. Copying the new member
+// without consulting it reads past the end of what the caller owns.
+//
+// These tests pin that down, because the failure is silent on a good day: the
+// value read is whatever the application happened to place after the struct,
+// and it ends up in a field CEF later treats as a pointer.
+
+namespace {
+
+#if CEF_API_ADDED(CEF_EXPERIMENTAL)
+
+// Size of cef_window_info_t as it was before |parent_xdg_surface| was added.
+constexpr size_t kSizeBeforeWaylandMembers =
+    offsetof(cef_window_info_t, parent_xdg_surface);
+
+// A cef_window_info_t truncated to an older layout, with a recognisable
+// pattern in the memory immediately after it. That pattern stands in for
+// whatever an application has next to the struct on its stack: if the copy
+// reads past |size|, it is what lands in the target.
+class TruncatedWindowInfo {
+ public:
+  static constexpr uintptr_t kPoison = 0x0badc0de0badc0deULL;
+
+  TruncatedWindowInfo() : storage_(sizeof(cef_window_info_t) * 2, 0) {
+    memset(storage_.data() + kSizeBeforeWaylandMembers, 0xde,
+           storage_.size() - kSizeBeforeWaylandMembers);
+    auto* poison = reinterpret_cast<uintptr_t*>(storage_.data() +
+                                                kSizeBeforeWaylandMembers);
+    *poison = kPoison;
+
+    get()->size = kSizeBeforeWaylandMembers;
+  }
+
+  cef_window_info_t* get() {
+    return reinterpret_cast<cef_window_info_t*>(storage_.data());
+  }
+
+ private:
+  std::vector<uint8_t> storage_;
+};
+
+TEST(CefWindowInfoLinuxTest, CopyingAnOlderStructDoesNotReadPastIt) {
+  TruncatedWindowInfo older;
+  older.get()->bounds = {1, 2, 3, 4};
+  older.get()->parent_window = 0x1234;
+
+  CefWindowInfo target;
+  target = *older.get();
+
+  // The members the older application does have are copied.
+  EXPECT_EQ(target.bounds.x, 1);
+  EXPECT_EQ(target.bounds.width, 3);
+  EXPECT_EQ(target.parent_window, static_cast<cef_window_handle_t>(0x1234));
+
+  // The one it does not have is cleared, not filled with what followed it.
+  EXPECT_EQ(target.parent_xdg_surface, nullptr);
+  EXPECT_NE(reinterpret_cast<uintptr_t>(target.parent_xdg_surface),
+            TruncatedWindowInfo::kPoison);
+}
+
+// A target that has already been used must not keep a stale value when a
+// smaller source is assigned over it. Otherwise a second CreateBrowser() call
+// from an older application would inherit the previous browser's xdg_surface.
+TEST(CefWindowInfoLinuxTest, CopyingAnOlderStructClearsWhatItCannotSet) {
+  CefWindowInfo target;
+  auto* sentinel = reinterpret_cast<cef_xdg_surface_handle_t>(0x4321);
+  target.parent_xdg_surface = sentinel;
+  ASSERT_EQ(target.parent_xdg_surface, sentinel);
+
+  TruncatedWindowInfo older;
+  target = *older.get();
+
+  EXPECT_EQ(target.parent_xdg_surface, nullptr);
+}
+
+// The current layout round-trips in full, so the guard above does not cost
+// anything to an application built against this version.
+TEST(CefWindowInfoLinuxTest, CopyingACurrentStructKeepsEveryMember) {
+  CefWindowInfo source;
+  source.bounds = {5, 6, 7, 8};
+  source.parent_window = 0xabcd;
+  source.parent_xdg_surface = reinterpret_cast<cef_xdg_surface_handle_t>(0x99);
+
+  CefWindowInfo target;
+  target = source;
+
+  EXPECT_EQ(target.bounds.y, 6);
+  EXPECT_EQ(target.parent_window, static_cast<cef_window_handle_t>(0xabcd));
+  EXPECT_EQ(target.parent_xdg_surface,
+            reinterpret_cast<cef_xdg_surface_handle_t>(0x99));
+}
+
+// The three-argument overload is the whole API surface an embedder touches for
+// this; it must not disturb anything the two-argument one sets.
+TEST(CefWindowInfoLinuxTest, SetAsChildOverloadsAgreeOnTheSharedMembers) {
+  const CefRect bounds(10, 20, 30, 40);
+  auto* xdg = reinterpret_cast<cef_xdg_surface_handle_t>(0x77);
+
+  CefWindowInfo two_arg;
+  two_arg.SetAsChild(0x55, bounds);
+
+  CefWindowInfo three_arg;
+  three_arg.SetAsChild(0x55, xdg, bounds);
+
+  EXPECT_EQ(two_arg.parent_window, three_arg.parent_window);
+  EXPECT_EQ(two_arg.bounds.x, three_arg.bounds.x);
+  EXPECT_EQ(two_arg.bounds.height, three_arg.bounds.height);
+
+  // Only the new member differs, and the two-argument form leaves it null so
+  // that existing embedders keep the old behaviour exactly.
+  EXPECT_EQ(two_arg.parent_xdg_surface, nullptr);
+  EXPECT_EQ(three_arg.parent_xdg_surface, xdg);
+}
+
+#endif  // CEF_API_ADDED(CEF_EXPERIMENTAL)
+
+}  // namespace

--- a/patch/patch.cfg
+++ b/patch/patch.cfg
@@ -895,5 +895,24 @@ patches = [
     # Don't depend on histograms.xml when not in a git checkout.
     # Cherry-pick of https://crrev.com/27f8690db9
     'name': 'tools_metrics_27f8690',
-  }
+  },
+  {
+    # Linux: Allow a browser window to be embedded as a wl_subsurface of a
+    # wl_surface owned by the client application, the Wayland counterpart of
+    # what CefWindowX11 does on X11.
+    #
+    # - WaylandConnection can adopt an externally owned wl_display instead of
+    #   calling wl_display_connect(). A wl_surface is scoped to its connection
+    #   and wl_subcompositor_get_subsurface() rejects surfaces from a different
+    #   one, so embedding is impossible without joining the client's connection.
+    #   The dedicated wl_event_queue that lets Chromium coexist with the
+    #   client's event loop already exists upstream.
+    # - WaylandWindowManager can name a foreign wl_surface with a
+    #   gfx::AcceleratedWidget, so it can travel through
+    #   views::Widget::InitParams::parent_widget.
+    # - WaylandEmbeddedWindow attaches to such a surface as a wl_subsurface.
+    #
+    # https://github.com/chromiumembedded/cef/issues/2804
+    'name': 'ozone_wayland_embed_2804',
+  },
 ]

--- a/patch/patches/ozone_wayland_embed_2804.patch
+++ b/patch/patches/ozone_wayland_embed_2804.patch
@@ -1,0 +1,2726 @@
+diff --git ui/ozone/platform/wayland/BUILD.gn ui/ozone/platform/wayland/BUILD.gn
+index 8e2d3051633ac3560071bfe7beba6007851d8c92..87e5875688734b65267d8470bd0658c7a704556a 100644
+--- ui/ozone/platform/wayland/BUILD.gn
++++ ui/ozone/platform/wayland/BUILD.gn
+@@ -121,6 +121,8 @@ source_set("wayland") {
+     "host/wayland_data_source.h",
+     "host/wayland_drm.cc",
+     "host/wayland_drm.h",
++    "host/wayland_embedded_window.cc",
++    "host/wayland_embedded_window.h",
+     "host/wayland_event_source.cc",
+     "host/wayland_event_source.h",
+     "host/wayland_exchange_data_provider.cc",
+@@ -224,6 +226,8 @@ source_set("wayland") {
+     "host/zwp_text_input_v3.h",
+     "ozone_platform_wayland.cc",
+     "ozone_platform_wayland.h",
++    "wayland_embedder.cc",
++    "wayland_embedder.h",
+     "wayland_utils.cc",
+     "wayland_utils.h",
+   ]
+@@ -533,6 +537,7 @@ source_set("wayland_unittests") {
+     "host/wayland_connection_unittest.cc",
+     "host/wayland_cursor_factory_unittest.cc",
+     "host/wayland_data_drag_controller_unittest.cc",
++    "host/wayland_embedded_window_unittest.cc",
+     "host/wayland_event_source_unittest.cc",
+     "host/wayland_event_watcher_unittest.cc",
+     "host/wayland_exchange_data_provider_unittest.cc",
+diff --git ui/ozone/platform/wayland/common/wayland_util.cc ui/ozone/platform/wayland/common/wayland_util.cc
+index 193888cefc1846d2b3a22fbab9d76c5907c3a24b..b05a8f5202db77979f2dc91643fb323a6f0a3b9b 100644
+--- ui/ozone/platform/wayland/common/wayland_util.cc
++++ ui/ozone/platform/wayland/common/wayland_util.cc
+@@ -21,9 +21,11 @@
+ #include "ui/events/event.h"
+ #include "ui/gfx/geometry/skia_conversions.h"
+ #include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_embedded_window.h"
+ #include "ui/ozone/platform/wayland/host/wayland_shm_buffer.h"
+ #include "ui/ozone/platform/wayland/host/wayland_surface.h"
+ #include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/ozone/platform/wayland/wayland_embedder.h"
+ 
+ namespace wl {
+ 
+@@ -273,11 +275,33 @@ gfx::SizeF ApplyWaylandTransform(const gfx::SizeF& size,
+ ui::WaylandWindow* RootWindowFromWlSurface(wl_surface* surface) {
+   if (!surface)
+     return nullptr;
+-  auto* wayland_surface = static_cast<ui::WaylandSurface*>(
+-      wl_proxy_get_user_data(reinterpret_cast<wl_proxy*>(surface)));
+-  if (!wayland_surface)
+-    return nullptr;
+-  return wayland_surface->root_window();
++  // Resolve through Chromium's own registry rather than the surface's user
++  // data. On a connection shared with an embedding application the compositor
++  // hands back that application's surfaces too -- a toolkit drawing its own
++  // decorations has one per border -- and their user data belongs to it.
++  // Casting that to WaylandSurface dereferences a foreign pointer.
++  if (auto* wayland_surface = ui::ChromiumSurfaceFor(surface))
++    return wayland_surface->root_window();
++
++  // Not ours, and deliberately not resolved any further. Pointer, touch, tablet
++  // and drag events on an embedding application's surface are that
++  // application's business: they arrive in its surface coordinate space and
++  // usually land on its own decorations. Only the keyboard has to cross over,
++  // through KeyboardWindowFromWlSurface() below.
++  return nullptr;
++}
++
++ui::WaylandWindow* KeyboardWindowFromWlSurface(wl_surface* surface) {
++  if (auto* window = RootWindowFromWlSurface(surface)) {
++    return window;
++  }
++
++  // A wl_subsurface never receives wl_keyboard.enter; the event goes to the
++  // embedder's toplevel. Without this an embedded browser could not be typed
++  // into at all, which makes the keyboard -- and the text input that follows
++  // it -- the one class of event that crosses from a foreign surface into the
++  // window embedded in it.
++  return ui::EmbeddedWindowForForeignSurface(surface);
+ }
+ 
+ gfx::Rect TranslateWindowBoundsToParentDIP(ui::WaylandWindow* window,
+@@ -288,6 +312,28 @@ gfx::Rect TranslateWindowBoundsToParentDIP(ui::WaylandWindow* window,
+       window->GetBoundsInDIP(), parent_window->GetBoundsInDIP());
+ }
+ 
++gfx::Rect TranslateWindowBoundsToXdgParentDIP(
++    ui::WaylandWindow* window,
++    ui::WaylandWindow* xdg_parent_window) {
++  DCHECK(window);
++  DCHECK(xdg_parent_window);
++  // An embedded window borrows the embedding application's xdg_surface, and a
++  // popup anchored on it is measured in that application's surface coordinates
++  // -- the same space the embedded window's own bounds are already in.
++  // Subtracting its origin would displace every menu by the offset of the
++  // browser within the host window.
++  //
++  // Only for xdg_popups. A bubble is a wl_subsurface of the embedded window
++  // itself, so its position is relative to that window and the ordinary
++  // translation above is the correct one.
++  if (xdg_parent_window->AsWaylandEmbeddedWindow()) {
++    return wl::TranslateBoundsToParentCoordinates(
++        window->GetBoundsInDIP(),
++        gfx::Rect(xdg_parent_window->GetBoundsInDIP().size()));
++  }
++  return TranslateWindowBoundsToParentDIP(window, xdg_parent_window);
++}
++
+ std::vector<gfx::Rect> CreateRectsFromSkPath(const SkPath& path) {
+   SkRegion clip_region;
+   clip_region.setRect(path.getBounds().round());
+diff --git ui/ozone/platform/wayland/common/wayland_util.h ui/ozone/platform/wayland/common/wayland_util.h
+index a91aa52f38f7349f034210c16e0a2997da2827e1..cf39804882bad5c993cbaee14b17f9606ff1e1af 100644
+--- ui/ozone/platform/wayland/common/wayland_util.h
++++ ui/ozone/platform/wayland/common/wayland_util.h
+@@ -94,9 +94,16 @@ gfx::RectF ApplyWaylandTransform(const gfx::RectF& rect,
+ gfx::SizeF ApplyWaylandTransform(const gfx::SizeF& size,
+                                  wl_output_transform transform);
+ 
+-// Returns the root WaylandWindow for the given wl_surface.
++// Returns the root WaylandWindow for the given wl_surface, or null if the
++// surface is not Chromium's -- which it may not be when the connection is
++// shared with an embedding application.
+ ui::WaylandWindow* RootWindowFromWlSurface(wl_surface* surface);
+ 
++// As above, but also resolves an embedding application's surface to the window
++// embedded inside it. Only for wl_keyboard and text input, which are delivered
++// to the embedder's toplevel because a wl_subsurface cannot receive them.
++ui::WaylandWindow* KeyboardWindowFromWlSurface(wl_surface* surface);
++
+ // Returns bounds of the given window, adjusted to its subsurface. We need to
+ // adjust bounds because WaylandWindow::GetBounds() returns absolute bounds in
+ // pixels, but wl_subsurface works with bounds relative to the parent surface
+@@ -104,6 +111,15 @@ ui::WaylandWindow* RootWindowFromWlSurface(wl_surface* surface);
+ gfx::Rect TranslateWindowBoundsToParentDIP(ui::WaylandWindow* window,
+                                            ui::WaylandWindow* parent_window);
+ 
++// As above, for a window whose parent is the one supplying the xdg_surface it
++// anchors on rather than the surface it is a subsurface of. The two differ only
++// when that xdg parent is an embedded window, which borrows the embedding
++// application's xdg_surface and is therefore already measured in the same
++// coordinate space the popup will be.
++gfx::Rect TranslateWindowBoundsToXdgParentDIP(
++    ui::WaylandWindow* window,
++    ui::WaylandWindow* xdg_parent_window);
++
+ // Returns rectangles dictated by SkPath.
+ std::vector<gfx::Rect> CreateRectsFromSkPath(const SkPath& path);
+ 
+diff --git ui/ozone/platform/wayland/host/wayland_connection.cc ui/ozone/platform/wayland/host/wayland_connection.cc
+index 4c44eaeebe091906a1676da106faa9072819b67e..e2373c251bdd50c3a18732c3c967710bbcc08382 100644
+--- ui/ozone/platform/wayland/host/wayland_connection.cc
++++ ui/ozone/platform/wayland/host/wayland_connection.cc
+@@ -9,6 +9,8 @@
+ #include <presentation-time-client-protocol.h>
+ #include <xdg-shell-client-protocol.h>
+ 
++#include <tuple>
++
+ #include <cstdint>
+ 
+ #include "base/command_line.h"
+@@ -69,6 +71,7 @@
+ #include "ui/ozone/platform/wayland/host/zwp_primary_selection_device_manager.h"
+ #include "ui/ozone/platform/wayland/host/zwp_text_input_v1.h"
+ #include "ui/ozone/platform/wayland/host/zwp_text_input_v3.h"
++#include "ui/ozone/platform/wayland/wayland_embedder.h"
+ #include "ui/ozone/public/ozone_switches.h"
+ #include "ui/platform_window/common/platform_window_defaults.h"
+ 
+@@ -138,9 +141,28 @@ bool MinSupportedKernelForLinuxDrmSyncobj() {
+ WaylandConnection::WaylandConnection() = default;
+ 
+ WaylandConnection::~WaylandConnection() {
++  SetWaylandConnectionForEmbedders(nullptr, nullptr);
++
++  // Destroying the seat makes WaylandPointer report a final focus change, which
++  // dispatches an event into whichever window still holds the pointer, and that
++  // window asks the screen for its scale factor. The seat therefore has to go
++  // before the ResetConnection() below, and that is the whole point of doing it
++  // explicitly: the destructor body runs ahead of member destruction, so member
++  // order cannot express it. (Declaration order does already destroy |seat_|
++  // before |window_manager_|; the ordering that needed forcing is against the
++  // screen, not against them.)
++  seat_.reset();
++
+   if (wayland_output_manager() && wayland_output_manager()->wayland_screen()) {
+     wayland_output_manager()->wayland_screen()->ResetConnection();
+   }
++
++  // Everything below holds proxies created on |display_|, so they must be gone
++  // before the display goes away. For an adopted display we additionally must
++  // not disconnect: the embedding application still needs it.
++  if (!owns_display_) {
++    std::ignore = display_.release();
++  }
+ }
+ 
+ bool WaylandConnection::Initialize(bool use_threaded_polling) {
+@@ -197,10 +219,18 @@ bool WaylandConnection::Initialize(bool use_threaded_polling) {
+   RegisterGlobalObjectFactory(ZwpPrimarySelectionDeviceManager::kInterfaceName,
+                               &ZwpPrimarySelectionDeviceManager::Instantiate);
+ 
+-  display_.reset(wl_display_connect(nullptr));
+-  if (!display_) {
+-    PLOG(ERROR) << "Failed to connect to Wayland display";
+-    return false;
++  if (wl_display* external_display = GetExternalWaylandDisplay()) {
++    // Adopted from an embedding application. Ownership stays with them, so
++    // release before destruction rather than calling wl_display_disconnect().
++    owns_display_ = false;
++    display_.reset(external_display);
++    VLOG(1) << "Using Wayland display provided by the embedding application";
++  } else {
++    display_.reset(wl_display_connect(nullptr));
++    if (!display_) {
++      PLOG(ERROR) << "Failed to connect to Wayland display";
++      return false;
++    }
+   }
+ 
+   wrapped_display_.reset(
+@@ -210,6 +240,8 @@ bool WaylandConnection::Initialize(bool use_threaded_polling) {
+   event_queue_.reset(wl_display_create_queue(display()));
+   wl_proxy_set_queue(wrapped_display_.get(), event_queue_.get());
+ 
++  SetWaylandConnectionForEmbedders(this, display());
++
+   registry_.reset(GetRegistry());
+   if (!registry_) {
+     LOG(ERROR) << "Failed to get Wayland registry";
+diff --git ui/ozone/platform/wayland/host/wayland_connection.h ui/ozone/platform/wayland/host/wayland_connection.h
+index 241a1e5ae9c5c176d8424b08d6f691f2e9fa94b3..0337e88611589a300248d2c476087b2c137f2c38 100644
+--- ui/ozone/platform/wayland/host/wayland_connection.h
++++ ui/ozone/platform/wayland/host/wayland_connection.h
+@@ -78,8 +78,21 @@ class WaylandConnection {
+   WaylandConnection& operator=(const WaylandConnection&) = delete;
+   ~WaylandConnection();
+ 
++  // If an embedding application called SetExternalWaylandDisplay(), this joins
++  // that wl_display instead of calling wl_display_connect(). Embedding a
++  // browser surface into a surface owned by another client requires it: a
++  // wl_surface is scoped to its connection and
++  // wl_subcompositor_get_subsurface() rejects surfaces from a different one.
++  //
++  // Chromium already routes its own protocol traffic through a dedicated
++  // wl_event_queue, so it coexists with the embedder's event loop on the
++  // default queue. An adopted display is never disconnected here; the embedder
++  // owns it and must outlive this connection.
+   bool Initialize(bool use_threaded_polling = false);
+ 
++  // True if this connection was adopted from an embedding application.
++  bool owns_display() const { return owns_display_; }
++
+   // Immediately flushes the Wayland display.
+   void Flush();
+ 
+@@ -396,6 +409,9 @@ class WaylandConnection {
+ 
+   uint32_t compositor_version_ = 0;
+   wl::Object<wl_display> display_;
++  // False when |display_| was adopted from an embedding application, in which
++  // case it must not be disconnected.
++  bool owns_display_ = true;
+   // `event_queue_` must be declared before `wrapped_display_`, so that the
+   // latter is destroyed first. This prevents libwayland warnings about the
+   // queue being destroyed while the proxy is still attached.
+diff --git ui/ozone/platform/wayland/host/wayland_embedded_window.cc ui/ozone/platform/wayland/host/wayland_embedded_window.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d33f0137aa88b00d746b8c6089e97c4a1eeea1f
+--- /dev/null
++++ ui/ozone/platform/wayland/host/wayland_embedded_window.cc
+@@ -0,0 +1,468 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/ozone/platform/wayland/host/wayland_embedded_window.h"
++
++#include "base/logging.h"
++#include "ui/events/event.h"
++#include "ui/events/types/event_type.h"
++#include "ui/gfx/geometry/rect.h"
++#include "ui/gfx/geometry/rect_conversions.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_output_manager.h"
++#include "ui/ozone/platform/wayland/host/wayland_screen.h"
++#include "ui/ozone/platform/wayland/host/wayland_surface.h"
++#include "ui/ozone/platform/wayland/host/wayland_window_manager.h"
++#include "ui/platform_window/platform_window_init_properties.h"
++
++namespace ui {
++
++WaylandEmbeddedWindow::WaylandEmbeddedWindow(PlatformWindowDelegate* delegate,
++                                             WaylandConnection* connection,
++                                             wl_surface* parent_surface,
++                                             xdg_surface* parent_xdg_surface)
++    : WaylandWindow(delegate, connection),
++      parent_surface_(parent_surface),
++      parent_xdg_surface_(parent_xdg_surface) {
++  CHECK(parent_surface_);
++  // Claim focus routing for this surface now; a sibling that is activated later
++  // takes it over. Without an initial claim a host that never calls SetFocus()
++  // would have no window to route keyboard input to at all.
++  connection->window_manager()->SetEmbeddedWindowForForeignSurface(
++      parent_surface_, this);
++  LOG_IF(WARNING, !parent_xdg_surface_)
++      << "No xdg_surface was provided for the embedded window; menus, tooltips "
++         "and <select> dropdowns will fall back to a wl_subsurface, which "
++         "cannot extend past the host window or be dismissed by clicking "
++         "outside it";
++}
++
++WaylandEmbeddedWindow* WaylandEmbeddedWindow::AsWaylandEmbeddedWindow() {
++  return this;
++}
++
++WaylandEmbeddedWindow::~WaylandEmbeddedWindow() {
++  connection()->window_manager()->RemoveEmbeddedWindowForForeignSurface(
++      parent_surface_, this);
++}
++
++void WaylandEmbeddedWindow::Show(bool inactive) {
++  if (subsurface_) {
++    return;
++  }
++
++  AttachToParentSurface();
++  WaylandWindow::Show(inactive);
++}
++
++void WaylandEmbeddedWindow::Hide() {
++  if (!subsurface_) {
++    return;
++  }
++
++  WaylandWindow::Hide();
++  // Deactivating reaches the views delegate, which may close the widget from
++  // there and destroy this window before the teardown below runs. Unlike
++  // Activate(), this one is not deferred: it is not reached from
++  // Widget::Show(), and a hidden window has to stop being active immediately.
++  auto weak_this = AsWeakPtr();
++  Deactivate();
++  if (!weak_this) {
++    return;
++  }
++  subsurface_.reset();
++  connection()->Flush();
++}
++
++bool WaylandEmbeddedWindow::IsVisible() const {
++  return !!subsurface_;
++}
++
++void WaylandEmbeddedWindow::SetBoundsInDIP(const gfx::Rect& bounds_dip) {
++  const auto old_bounds_dip = GetBoundsInDIP();
++  auto weak_this = AsWeakPtr();
++  WaylandWindow::SetBoundsInDIP(bounds_dip);
++  if (!weak_this) {
++    return;
++  }
++
++  if (subsurface_ && old_bounds_dip != bounds_dip) {
++    SetSubsurfacePosition();
++  }
++}
++
++void WaylandEmbeddedWindow::UpdateActivationState() {
++  // The same rule WaylandToplevelWindow applies to itself: activation has to
++  // describe where input actually goes, and the seat is the only authority on
++  // that. Called by the window manager on both sides of every focus
++  // transition, so wl_keyboard.enter and .leave drive it as well.
++  bool active = active_;
++  auto* manager = connection()->window_manager();
++  if (connection()->IsKeyboardAvailable()) {
++    active = manager->GetCurrentKeyboardFocusedWindow() == this;
++  } else if (connection()->SupportsTextInputFocus()) {
++    // With no physical keyboard an input method is the only way text arrives,
++    // so its focus is the signal.
++    active = manager->GetCurrentTextInputFocusedWindow() == this;
++  } else {
++    // Neither exists. A toplevel falls back to xdg_toplevel.activated here; an
++    // embedded window has no xdg_toplevel, so the embedder's own request is the
++    // only remaining source -- and it is a real one, since the embedder is the
++    // party that decides which of its panels is focused.
++    active = embedder_requested_active_;
++  }
++  if (active_ == active) {
++    return;
++  }
++  active_ = active;
++
++  // Routed the way WaylandToplevelWindow routes it. With an active bubble the
++  // transition belongs to the bubble: it is what holds the keyboard
++  // (WaylandWindow::DispatchEvent redirects there) and what has to be dismissed
++  // when this window stops being active. Notifying our own delegate instead
++  // would leave the bubble active with no one telling it otherwise.
++  if (active_bubble()) {
++    ActivateBubble(active ? active_bubble() : nullptr);
++    return;
++  }
++  std::ignore = NotifyActivationChanged(active);
++}
++
++bool WaylandEmbeddedWindow::NotifyActivationChanged(bool active) {
++  active_ = active;
++
++  // Views keeps its own notion of which widget is active and it is fed only
++  // from here. WaylandWindow::Activate() does not do it; WaylandToplevelWindow
++  // calls the delegate explicitly for the same reason.
++  //
++  // Inline, not deferred: one dispatch of the Wayland queue drains every
++  // pending event, so a key sitting behind wl_keyboard.enter would otherwise
++  // reach views before views had been told the window was active.
++  //
++  // Returns false if the delegate destroyed this window from here.
++  auto alive = weak_ptr_factory_.GetWeakPtr();
++  delegate()->OnActivationChanged(active);
++  return !!alive;
++}
++
++void WaylandEmbeddedWindow::Activate() {
++  embedder_requested_active_ = true;
++  // Keyboard events arrive on the embedder's surface, so the map has to say
++  // which of the windows sharing it should receive them. Recorded immediately;
++  // only the focus move below is deferred.
++  connection()->window_manager()->SetEmbeddedWindowForForeignSurface(
++      parent_surface_, this);
++
++  // Dismisses an active bubble, notifying its delegate and then ours -- either
++  // of which may destroy this window.
++  auto weak_this = AsWeakPtr();
++  WaylandWindow::Activate();
++  if (!weak_this) {
++    return;
++  }
++
++  // See TakeFocusIfAvailable() for why this does not resolve here.
++  if (activation_request_pending_) {
++    return;
++  }
++  activation_request_pending_ = true;
++  base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
++      FROM_HERE, base::BindOnce(&WaylandEmbeddedWindow::TakeFocusIfAvailable,
++                                weak_ptr_factory_.GetWeakPtr()));
++}
++
++void WaylandEmbeddedWindow::TakeFocusIfAvailable() {
++  activation_request_pending_ = false;
++
++  // The request can be withdrawn between posting and running: a host that
++  // deactivates or hides the browser in the same turn of the loop, or a
++  // Show() immediately followed by Hide(). Without this the task would undo
++  // the Deactivate() it was overtaken by and hand focus back to a window the
++  // embedder has already dismissed.
++  if (!embedder_requested_active_) {
++    return;
++  }
++
++  auto* manager = connection()->window_manager();
++
++  // Everything below decides whether the keyboard actually moves here, and the
++  // delegate is told only if it does: Widget::Show() calls Activate() on every
++  // browser it shows, so claiming activation on request alone would leave views
++  // believing several browsers are focused at once. The map is not enough
++  // either, since wl_keyboard.enter fires once and is never repeated while
++  // focus stays inside the embedder's window, so the stored focus is taken
++  // over below rather than only recorded.
++  //
++  // Gated on IsKeyboardAvailable() because keyboard_focused_foreign_surface_ is
++  // written from wl_keyboard.enter and nowhere else: on a touch-only or
++  // virtual-keyboard system it is never set, and gating on it unconditionally
++  // would make every Activate() return early.
++  if (connection()->IsKeyboardAvailable() &&
++      manager->keyboard_focused_foreign_surface() != parent_surface_) {
++    return;
++  }
++
++  // Only from a sibling sharing this embedder surface, or from nothing at all.
++  // A Chromium toplevel of its own -- a Views window opened by the same
++  // process -- holds the focus legitimately, and the recorded foreign surface
++  // may be left over from an earlier enter.
++  //
++  // Both kinds of focus have to be consulted, not just the keyboard. Where
++  // there is no keyboard the seat still routes text through
++  // zwp_text_input_v3, and a toplevel holding that focus is exactly as
++  // legitimate an owner; checking only the keyboard would let this window take
++  // the input method away from it while the compositor kept delivering there.
++  auto* holder = manager->GetCurrentKeyboardFocusedWindow();
++  if (!holder) {
++    holder = manager->GetCurrentTextInputFocusedWindow();
++  }
++  auto* sibling = holder ? holder->AsWaylandEmbeddedWindow() : nullptr;
++  if (holder && holder != this &&
++      !(sibling && sibling->parent_surface() == parent_surface_)) {
++    return;
++  }
++
++  // Exclusivity and the delegate notification both come out of this call:
++  // WaylandWindowManager updates the activation state of every window on both
++  // sides of the transition, which is how a toplevel learns it too. Doing it
++  // here rather than by hand also covers the case where the keyboard was
++  // already on this window -- focus set by wl_keyboard.enter rather than by the
++  // embedder -- and no notification had been sent yet.
++  // Only where a keyboard exists. Synthesising a keyboard focus on a seat that
++  // has none leaves a value nothing will ever clear, and the check above would
++  // then read it back as this window legitimately holding focus -- letting a
++  // later Activate() overwrite a text-input focus the compositor had since
++  // given to a toplevel.
++  auto weak_this = AsWeakPtr();
++  if (connection()->IsKeyboardAvailable()) {
++    manager->SetKeyboardFocusedWindow(this);
++    if (!weak_this) {
++      return;
++    }
++  }
++
++  // Text input focus has to move with it: zwp_text_input_v3 enter/leave are
++  // delivered for the embedder's toplevel and are not repeated when the host
++  // moves between two browsers inside it.
++  //
++  // Moved, never invented. text-input-v3 defines enable against the surface a
++  // previous zwp_text_input_v3.enter named, not a wl_keyboard.enter, which is a
++  // different focus with a different event that some compositors send while
++  // never sending the text-input one. The evidence is therefore the recorded
++  // text-input surface, or a sibling already holding a focus that came from
++  // one.
++  auto* text_holder = manager->GetCurrentTextInputFocusedWindow();
++  auto* text_sibling =
++      text_holder ? text_holder->AsWaylandEmbeddedWindow() : nullptr;
++  const bool text_focus_is_on_this_embedder =
++      (text_sibling && text_sibling->parent_surface() == parent_surface_) ||
++      manager->text_input_focused_foreign_surface() == parent_surface_;
++  if (text_holder != this && text_focus_is_on_this_embedder) {
++    manager->SetTextInputFocusedWindow(this);
++    if (!weak_this) {
++      return;
++    }
++  }
++
++  // Usually a no-op: SetKeyboardFocusedWindow() above already ran this through
++  // the manager. It is repeated for the cases that produce no focus transition
++  // at all -- no keyboard on the seat, or the focus already here -- where the
++  // manager is never reached.
++  UpdateActivationState();
++}
++
++uint32_t WaylandEmbeddedWindow::DispatchEvent(
++    const PlatformEvent& native_event) {
++  // Compositors hand keyboard focus to whatever toplevel the user clicks. An
++  // embedded window is invisible to that policy: it has no toplevel of its own
++  // and never receives wl_keyboard.enter, so clicking one would leave the keys
++  // going wherever they went before. Reproduce click-to-focus here, otherwise
++  // every host would have to call SetFocus() from its own click handler just
++  // to make typing follow the pointer.
++  const auto type = static_cast<Event*>(native_event)->type();
++  if (type == EventType::kMousePressed || type == EventType::kTouchPressed) {
++    // Resolved here rather than through Activate(), which defers. One dispatch
++    // of the Wayland queue drains every pending event, so a key queued behind
++    // this click would otherwise be delivered to whichever browser held focus
++    // before it -- WaylandEventSource reads the stored focus, and the posted
++    // task would not have run yet. Deferring exists to keep a destructive
++    // delegate callback out of Widget::Show(); this path is not Show().
++    embedder_requested_active_ = true;
++    connection()->window_manager()->SetEmbeddedWindowForForeignSurface(
++        parent_surface_, this);
++    auto weak_this = AsWeakPtr();
++    // Same order Activate() uses: dismiss any active bubble first, then take
++    // the focus. Skipping the base call would leave a bubble holding the
++    // keyboard while this window believed it had it.
++    WaylandWindow::Activate();
++    if (!weak_this) {
++      return POST_DISPATCH_STOP_PROPAGATION;
++    }
++    TakeFocusIfAvailable();
++    if (!weak_this) {
++      return POST_DISPATCH_STOP_PROPAGATION;
++    }
++  }
++  return WaylandWindow::DispatchEvent(native_event);
++}
++
++void WaylandEmbeddedWindow::Deactivate() {
++  embedder_requested_active_ = false;
++  auto* manager = connection()->window_manager();
++
++  // Taken before the first call that can reach a delegate. Both Set* below run
++  // the manager's activation update, which since the notification became inline
++  // ends in OnActivationChanged(false) -- documented as free to close the
++  // widget and destroy this window from there.
++  auto weak_this = AsWeakPtr();
++
++  // Give up the routing entry, not just the current focus. Clearing only the
++  // focus would hand the keyboard straight back on the next wl_keyboard.enter
++  // -- the user moving the pointer out of the host window and in again -- to a
++  // browser the embedder has since deactivated or hidden.
++  manager->RemoveEmbeddedWindowForForeignSurface(parent_surface_, this);
++
++  if (manager->GetCurrentKeyboardFocusedWindow() == this) {
++    manager->SetKeyboardFocusedWindow(nullptr);
++    if (!weak_this) {
++      return;
++    }
++  }
++  if (manager->GetCurrentTextInputFocusedWindow() == this) {
++    manager->SetTextInputFocusedWindow(nullptr);
++    if (!weak_this) {
++      return;
++    }
++  }
++
++  // As in Activate(): the manager notifies on the focus transition. This covers
++  // the case where the embedder deactivates a browser that never held the
++  // keyboard, which produces no transition at all.
++  UpdateActivationState();
++  if (!weak_this) {
++    return;
++  }
++  WaylandWindow::Deactivate();
++}
++
++void WaylandEmbeddedWindow::OnSequencePoint(int64_t seq) {
++  if (!subsurface_) {
++    return;
++  }
++
++  ProcessSequencePoint(seq);
++  MaybeApplyLatestStateRequest(/*force=*/false);
++}
++
++base::WeakPtr<WaylandWindow> WaylandEmbeddedWindow::AsWeakPtr() {
++  return weak_ptr_factory_.GetWeakPtr();
++}
++
++bool WaylandEmbeddedWindow::IsActive() const {
++  // A wl_subsurface never holds the seat's keyboard focus, so there is no
++  // protocol event to derive this from. The embedder drives it through
++  // Activate()/Deactivate().
++  return active_;
++}
++
++void WaylandEmbeddedWindow::AttachToParentSurface() {
++  subsurface_ =
++      root_surface()->CreateSubsurfaceForForeignParent(parent_surface_.get());
++  if (!subsurface_) {
++    LOG(ERROR) << "Failed to create wl_subsurface for embedded window; is the "
++                  "parent surface from the same wl_display?";
++    return;
++  }
++
++  SetSubsurfacePosition();
++
++  // This window has its own ui::Compositor and receives BeginFrames
++  // independently of the embedder, so its frames must not wait for a commit on
++  // the parent surface.
++  wl_subsurface_set_desync(subsurface_.get());
++
++  // Subsurfaces never receive configure events. As soon as the wl_subsurface
++  // exists it is considered configured, otherwise frame_manager_ would never
++  // start processing frames.
++  OnSurfaceConfigureEvent();
++  connection()->window_manager()->NotifyWindowConfigured(this);
++
++  connection()->Flush();
++}
++
++void WaylandEmbeddedWindow::SetSubsurfacePosition() {
++  // Unlike WaylandBubble, there is no parent WaylandWindow whose geometry the
++  // bounds could be translated against: the embedder specifies bounds directly
++  // in the parent surface's coordinate space, so there is no origin to
++  // subtract. The scale still has to be undone -- GetBoundsInDIP() is in the
++  // UI coordinate space that the upper layers work in, and set_position takes
++  // Wayland DIP -- which is the same reverse transform WaylandPopup applies
++  // before issuing an xdg_positioner request.
++  const auto bounds_in_parent = gfx::ScaleToEnclosingRectIgnoringError(
++      GetBoundsInDIP(), applied_state().ui_scale);
++  wl_subsurface_set_position(subsurface_.get(), bounds_in_parent.x(),
++                             bounds_in_parent.y());
++
++  // wl_subsurface.set_position is part of the parent surface's double-buffered
++  // state, so it only takes effect on the parent's next commit. We deliberately
++  // do not commit the parent here: it belongs to the embedder, and committing
++  // it behind their back would publish whatever partial state they had pending.
++  // The move lands when the embedder next commits, which it does whenever it
++  // repaints after moving us.
++  connection()->Flush();
++}
++
++bool WaylandEmbeddedWindow::OnInitialize(
++    PlatformWindowInitProperties properties,
++    PlatformWindowDelegate::State* state) {
++  state->window_state = PlatformWindowState::kNormal;
++
++  // There is no parent WaylandWindow to inherit scale from, and
++  // WaylandWindow::Initialize() takes state->window_scale as final -- it does
++  // not call UpdateWindowScale() afterwards -- so whatever is chosen here is
++  // what the opening frames render at.
++  //
++  // A sibling already embedded in the same surface is the best answer: it is on
++  // the same output by construction and the compositor has already told it the
++  // scale. WaylandSurface seeds preferred_scale_factor_ from that sibling for
++  // exactly this purpose, and it has to be read back here -- left in the
++  // surface's cache alone it changes nothing, and a browser added while the
++  // host sits on a fractional output renders at the primary display's scale and
++  // stays blurry until dragged to another output and back.
++  float scale = 0.f;
++  if (auto inherited = GetPreferredScaleFactor()) {
++    scale = *inherited;
++  }
++
++  // No sibling to ask. The primary display is the only hint left, since the
++  // output the embedder's surface sits on cannot be queried; wl_surface.enter
++  // and wp_fractional_scale_v1.preferred_scale refine it afterwards.
++  if (scale <= 0.f) {
++    if (auto* output_manager = connection()->wayland_output_manager()) {
++      if (auto* screen = output_manager->wayland_screen()) {
++        const float primary = screen->GetPrimaryDisplay().device_scale_factor();
++        if (primary > 0.f) {
++          scale = primary;
++        }
++      }
++    }
++  }
++  state->window_scale = scale > 0.f ? scale : 1.0f;
++
++  return true;
++}
++
++bool WaylandEmbeddedWindow::IsSurfaceConfigured() {
++  // The server raises unconfigured_buffer if a buffer is attached to an
++  // unconfigured toplevel or popup, but a subsurface counts as configured for
++  // as long as it has a wl_subsurface handle.
++  return !!subsurface_;
++}
++
++void WaylandEmbeddedWindow::UpdateWindowMask() {
++  // The embedder owns the window shape; we occupy the rectangle it gave us.
++  root_surface()->set_opaque_region(std::nullopt);
++}
++
++}  // namespace ui
+diff --git ui/ozone/platform/wayland/host/wayland_embedded_window.h ui/ozone/platform/wayland/host/wayland_embedded_window.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..ee2375d840569e52b4706348b4f3d09bd7835a2b
+--- /dev/null
++++ ui/ozone/platform/wayland/host/wayland_embedded_window.h
+@@ -0,0 +1,141 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_EMBEDDED_WINDOW_H_
++#define UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_EMBEDDED_WINDOW_H_
++
++#include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/platform_window/platform_window_init_properties.h"
++
++struct wl_surface;
++struct xdg_surface;
++
++namespace ui {
++
++// A WaylandWindow attached as a wl_subsurface of a wl_surface that belongs to
++// the embedding application rather than to Chromium.
++//
++// This is what makes it possible to host web content inside a window owned by a
++// third-party Wayland client, the way CefWindowX11 does on X11. It differs from
++// WaylandBubble, which is also subsurface-based, in that the parent is a bare
++// wl_surface with no corresponding WaylandWindow: Chromium knows nothing about
++// it beyond the proxy pointer, and cannot query its size, position, scale or
++// activation state.
++//
++// The parent surface must belong to the same wl_display as this window. A
++// wl_surface is scoped to its connection and wl_subcompositor_get_subsurface()
++// rejects surfaces from different connections, which is why the embedder has to
++// hand its wl_display to WaylandConnection at startup.
++//
++// Consequences of having no parent WaylandWindow:
++//   * Bounds are taken at face value, relative to the parent surface origin.
++//     There is no parent geometry to translate against.
++//   * wl_subsurface.set_position is double-buffered on the *parent* surface, so
++//     a move only takes effect when the embedder next commits. This class does
++//     not commit the parent surface, because doing so would race with the
++//     embedder's own rendering.
++//   * Keyboard focus is never delivered here; wl_keyboard.enter goes to the
++//     embedder's toplevel. Activation is driven explicitly instead.
++class WaylandEmbeddedWindow final : public WaylandWindow {
++ public:
++  // |parent_xdg_surface| is the embedding application's xdg_surface, or null.
++  // A wl_subsurface has no xdg_surface role of its own and
++  // xdg_surface.get_popup requires one, so without it the browser cannot open
++  // menus, tooltips or <select> dropdowns. See
++  // WaylandEmbeddedWindow::foreign_xdg_surface().
++  WaylandEmbeddedWindow(PlatformWindowDelegate* delegate,
++                        WaylandConnection* connection,
++                        wl_surface* parent_surface,
++                        xdg_surface* parent_xdg_surface);
++  WaylandEmbeddedWindow(const WaylandEmbeddedWindow&) = delete;
++  WaylandEmbeddedWindow& operator=(const WaylandEmbeddedWindow&) = delete;
++  ~WaylandEmbeddedWindow() override;
++
++  // PlatformWindow overrides:
++  void Show(bool inactive) override;
++  void Hide() override;
++  bool IsVisible() const override;
++  void SetBoundsInDIP(const gfx::Rect& bounds) override;
++  void Activate() override;
++  void Deactivate() override;
++
++  // PlatformEventDispatcher overrides:
++  uint32_t DispatchEvent(const PlatformEvent& event) override;
++
++  // WaylandWindow overrides:
++  void OnSequencePoint(int64_t seq) override;
++  void AckConfigure(uint32_t serial) override {}
++  base::WeakPtr<WaylandWindow> AsWeakPtr() override;
++  bool IsActive() const override;
++
++  // Recomputes activation from the seat and tells the delegate if it changed.
++  // Called by WaylandWindowManager on both sides of every focus transition,
++  // the same way WaylandToplevelWindow is driven.
++  void UpdateActivationState();
++  WaylandEmbeddedWindow* AsWaylandEmbeddedWindow() override;
++
++  // The embedder's xdg_surface, used as the parent of any xdg_popup this window
++  // spawns. Popups are anchored on the embedder's window geometry, so their
++  // anchor rectangles are expressed in that surface's coordinate space rather
++  // than relative to this window. Null if the embedder did not provide one, in
++  // which case popups cannot be created at all.
++  xdg_surface* foreign_xdg_surface() const { return parent_xdg_surface_; }
++
++  // The embedding application's surface this window is attached to.
++  wl_surface* parent_surface() const { return parent_surface_; }
++
++ private:
++  // WaylandWindow overrides:
++  bool OnInitialize(PlatformWindowInitProperties properties,
++                    PlatformWindowDelegate::State* state) override;
++  bool IsSurfaceConfigured() override;
++  void UpdateWindowMask() override;
++
++  void AttachToParentSurface();
++  void SetSubsurfacePosition();
++
++  // Records the new activation state and tells the delegate, inline. Returns
++  // false if the delegate destroyed this window in response, which views
++  // documents it may do. Inline on purpose: WaylandToplevelWindow notifies the
++  // same way from the same manager path, and one dispatch of the Wayland queue
++  // drains every pending event, so deferring would let a key queued behind
++  // wl_keyboard.enter reach views before views knew the window was active.
++  [[nodiscard]] bool NotifyActivationChanged(bool active);
++
++  // The deferred half of Activate(). A toplevel's Activate() only asks the
++  // compositor and learns the answer from a later event, so views never sees a
++  // delegate callback from inside Widget::Show(). An embedded window has no
++  // compositor to ask and would otherwise resolve activation during that call,
++  // putting a possibly destructive callback in the middle of
++  // DesktopWindowTreeHostPlatform::Show(), which goes on using
++  // native_widget_delegate_ without rechecking its own WeakPtr.
++  void TakeFocusIfAvailable();
++
++  // Owned by the embedding application, not by us.
++  const raw_ptr<wl_surface> parent_surface_;
++  const raw_ptr<xdg_surface> parent_xdg_surface_;
++
++  wl::Object<wl_subsurface> subsurface_;
++
++  // Derived state: where input actually goes, per UpdateActivationState().
++  bool active_ = false;
++
++  // What the embedder last asked for through Activate()/Deactivate(). Used only
++  // when neither a keyboard nor an input method exists to derive from, which is
++  // the embedded equivalent of the xdg_toplevel.activated fallback a toplevel
++  // has and this window does not.
++  bool embedder_requested_active_ = false;
++
++  // Set while a TakeFocusIfAvailable() task is queued, so repeated Activate()
++  // calls collapse into one.
++  bool activation_request_pending_ = false;
++
++  base::WeakPtrFactory<WaylandEmbeddedWindow> weak_ptr_factory_{this};
++};
++
++}  // namespace ui
++
++#endif  // UI_OZONE_PLATFORM_WAYLAND_HOST_WAYLAND_EMBEDDED_WINDOW_H_
+diff --git ui/ozone/platform/wayland/host/wayland_embedded_window_unittest.cc ui/ozone/platform/wayland/host/wayland_embedded_window_unittest.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..01b68d4c1aae40a91535ab55577efac84090289f
+--- /dev/null
++++ ui/ozone/platform/wayland/host/wayland_embedded_window_unittest.cc
+@@ -0,0 +1,876 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/ozone/platform/wayland/host/wayland_embedded_window.h"
++
++#include <text-input-unstable-v3-server-protocol.h>
++#include <xdg-shell-client-protocol.h>
++
++#include "base/memory/raw_ptr.h"
++#include "testing/gtest/include/gtest/gtest.h"
++#include "ui/events/event.h"
++#include "ui/events/event_constants.h"
++#include "ui/events/types/event_type.h"
++#include "ui/ozone/platform/wayland/common/wayland_util.h"
++#include "ui/ozone/platform/wayland/host/wayland_seat.h"
++#include "ui/ozone/platform/wayland/host/wayland_window_manager.h"
++#include "ui/ozone/platform/wayland/test/mock_surface.h"
++#include "ui/ozone/platform/wayland/test/mock_wayland_platform_window_delegate.h"
++#include "ui/ozone/platform/wayland/test/mock_zwp_text_input.h"
++#include "ui/ozone/platform/wayland/test/test_zwp_text_input_manager.h"
++#include "ui/ozone/platform/wayland/test/wayland_test.h"
++#include "ui/ozone/platform/wayland/wayland_embedder.h"
++
++namespace ui {
++
++using ::testing::Values;
++
++namespace {
++
++constexpr gfx::Rect kPanelBounds(10, 20, 200, 100);
++
++}  // namespace
++
++// Covers hosting a browser inside a surface owned by another application: the
++// window that stands in for it, and the input routing that has to reach it even
++// though the compositor addresses everything to the embedder's toplevel.
++//
++// The embedder's surface is created here on the same connection, without going
++// through WaylandSurface, which is exactly what makes it foreign: Chromium
++// knows nothing about it beyond the proxy pointer.
++class WaylandEmbeddedWindowTest : public WaylandTest {
++ public:
++  WaylandEmbeddedWindowTest() = default;
++  WaylandEmbeddedWindowTest(const WaylandEmbeddedWindowTest&) = delete;
++  WaylandEmbeddedWindowTest& operator=(const WaylandEmbeddedWindowTest&) =
++      delete;
++  ~WaylandEmbeddedWindowTest() override = default;
++
++  void SetUp() override {
++    WaylandTest::SetUp();
++    manager_ = connection_->window_manager();
++    ASSERT_TRUE(manager_);
++
++    foreign_surface_ = wl_compositor_create_surface(connection_->compositor());
++    ASSERT_TRUE(foreign_surface_);
++  }
++
++  void TearDown() override {
++    if (foreign_widget_ != gfx::kNullAcceleratedWidget) {
++      UnregisterForeignWaylandSurface(foreign_widget_);
++      foreign_widget_ = gfx::kNullAcceleratedWidget;
++    }
++    if (foreign_xdg_surface_) {
++      xdg_surface_destroy(foreign_xdg_surface_.get());
++      foreign_xdg_surface_ = nullptr;
++    }
++    if (foreign_surface_) {
++      wl_surface_destroy(foreign_surface_);
++      foreign_surface_ = nullptr;
++    }
++    WaylandTest::TearDown();
++  }
++
++ protected:
++  // |with_xdg_surface| mirrors an embedder whose toolkit exposes its
++  // xdg_surface; passing false is the winit case, where popups cannot be
++  // anchored at all.
++  //
++  // A real xdg_surface rather than a stand-in pointer: XdgPopup::Initialize()
++  // passes it straight to xdg_surface.get_popup, so anything else segfaults in
++  // libwayland the first time a popup is opened.
++  gfx::AcceleratedWidget RegisterForeignParent(bool with_xdg_surface = true) {
++    if (with_xdg_surface) {
++      foreign_xdg_surface_ =
++          xdg_wm_base_get_xdg_surface(connection_->shell(), foreign_surface_);
++    }
++    foreign_widget_ = RegisterForeignWaylandSurface(foreign_surface_,
++                                                    foreign_xdg_surface_.get());
++    return foreign_widget_;
++  }
++
++  // Drives a real zwp_text_input_v3.enter from the test compositor for the
++  // embedder's surface, rather than writing the manager state by hand. This is
++  // the path the protocol actually takes: OnEnter has to record the foreign
++  // surface even when it resolves to no window yet.
++  void SendTextInputEnterForForeignSurface() {
++    ASSERT_TRUE(connection_->EnsureTextInputV3());
++    connection_->RoundTripQueue();
++    const uint32_t surface_id = wl_proxy_get_id(
++        reinterpret_cast<wl_proxy*>(foreign_surface_.get()));
++    PostToServerAndWait([surface_id](wl::TestWaylandServerThread* server) {
++      auto* text_input = server->text_input_manager_v3()->text_input();
++      ASSERT_TRUE(text_input);
++      auto* surface = server->GetObject<wl::MockSurface>(surface_id);
++      ASSERT_TRUE(surface);
++      zwp_text_input_v3_send_enter(text_input->resource(), surface->resource());
++    });
++  }
++
++  // Activation is derived from the seat, so the tests that exercise it need a
++  // keyboard to exist at all; without one UpdateActivationState() falls through
++  // to the embedder-request tier and the protocol path is never taken.
++  void PlugKeyboard() {
++    PostToServerAndWait([](wl::TestWaylandServerThread* server) {
++      wl_seat_send_capabilities(server->seat()->resource(),
++                                WL_SEAT_CAPABILITY_KEYBOARD);
++    });
++    ASSERT_TRUE(connection_->seat() && connection_->seat()->keyboard());
++  }
++
++  std::unique_ptr<WaylandWindow> CreateEmbedded(
++      MockWaylandPlatformWindowDelegate* delegate,
++      gfx::AcceleratedWidget parent) {
++    // kPopup on purpose: views maps Widget::InitParams::TYPE_CONTROL, which is
++    // what an embedded browser uses, onto it. The factory has to decide from
++    // the parent widget rather than the type.
++    return CreateWaylandWindowWithParams(PlatformWindowType::kPopup,
++                                         kPanelBounds, delegate, parent);
++  }
++
++  raw_ptr<WaylandWindowManager> manager_ = nullptr;
++  raw_ptr<wl_surface> foreign_surface_ = nullptr;
++  raw_ptr<struct xdg_surface> foreign_xdg_surface_ = nullptr;
++  gfx::AcceleratedWidget foreign_widget_ = gfx::kNullAcceleratedWidget;
++};
++
++// A parent widget naming a foreign surface produces an embedded window,
++// whatever PlatformWindowType views asked for.
++TEST_P(WaylandEmbeddedWindowTest, ForeignParentProducesAnEmbeddedWindow) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  ASSERT_NE(parent, gfx::kNullAcceleratedWidget);
++
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  auto* embedded = window->AsWaylandEmbeddedWindow();
++  ASSERT_TRUE(embedded);
++  EXPECT_EQ(embedded->parent_surface(), foreign_surface_);
++  // Corrected away from the kPopup views could not express.
++  EXPECT_EQ(window->type(), PlatformWindowType::kWindow);
++  // An embedded window has no parent WaylandWindow at all.
++  EXPECT_EQ(window->parent_window(), nullptr);
++}
++
++// Registration is what lets a foreign surface travel through
++// views::Widget::InitParams::parent_widget, and unregistration has to undo it.
++TEST_P(WaylandEmbeddedWindowTest, ForeignSurfaceRegistrationRoundTrips) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  ASSERT_NE(parent, gfx::kNullAcceleratedWidget);
++  EXPECT_EQ(manager_->GetForeignSurface(parent), foreign_surface_);
++  EXPECT_NE(manager_->GetForeignXdgSurface(parent), nullptr);
++
++  UnregisterForeignWaylandSurface(parent);
++  foreign_widget_ = gfx::kNullAcceleratedWidget;
++
++  EXPECT_EQ(manager_->GetForeignSurface(parent), nullptr);
++  EXPECT_EQ(manager_->GetForeignXdgSurface(parent), nullptr);
++
++  // And the factory no longer treats that widget as an embedder: the type
++  // views asked for decides again, so this is an ordinary popup rather than an
++  // embedded window.
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  if (window) {
++    EXPECT_EQ(window->AsWaylandEmbeddedWindow(), nullptr);
++  }
++  EXPECT_EQ(wl::KeyboardWindowFromWlSurface(foreign_surface_), nullptr);
++}
++
++// The distinction M1 turns on: pointer, touch and drag events arriving on the
++// embedder's surface belong to the embedder and must not resolve into the
++// browser, while the keyboard has to cross over or an embedded browser could
++// never be typed into.
++TEST_P(WaylandEmbeddedWindowTest, OnlyTheKeyboardCrossesFromAForeignSurface) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  EXPECT_EQ(wl::RootWindowFromWlSurface(foreign_surface_), nullptr);
++  EXPECT_EQ(wl::KeyboardWindowFromWlSurface(foreign_surface_), window.get());
++
++  // Chromium's own surfaces keep resolving through the ordinary path.
++  ASSERT_TRUE(window->root_surface());
++  EXPECT_EQ(wl::RootWindowFromWlSurface(window->root_surface()->surface()),
++            window.get());
++}
++
++// wl_keyboard.enter fires once for the embedder's toplevel and is not repeated
++// while focus stays inside it, so activating a sibling has to take the stored
++// focus over. Without this only the browser that happened to own the routing
++// map at enter time ever receives keys.
++TEST_P(WaylandEmbeddedWindowTest, ActivateMovesKeyboardFocusBetweenSiblings) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate_a(connection_.get());
++  MockWaylandPlatformWindowDelegate delegate_b(connection_.get());
++  auto first = CreateEmbedded(&delegate_a, parent);
++  auto second = CreateEmbedded(&delegate_b, parent);
++  ASSERT_TRUE(first);
++  ASSERT_TRUE(second);
++
++  // What the two enter events would have left behind: the seat's keyboard and
++  // its text input are both on the embedder's surface, and each resolved to
++  // whichever window owned the map at the time. Text input is recorded
++  // separately on purpose -- a keyboard enter is not evidence of a text-input
++  // one, and without this the activation below would refuse to move it.
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  manager_->SetTextInputFocusedForeignSurface(foreign_surface_);
++  manager_->SetKeyboardFocusedWindow(first.get());
++  ASSERT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), first.get());
++
++  second->Activate();
++  task_environment_.RunUntilIdle();
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), second.get());
++  // Text input has to follow, or composition keeps landing on the old one.
++  EXPECT_EQ(manager_->GetCurrentTextInputFocusedWindow(), second.get());
++
++  first->Activate();
++  task_environment_.RunUntilIdle();
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), first.get());
++}
++
++// Taking focus is only legitimate from a sibling sharing the same embedder
++// surface. A Chromium toplevel of its own holds the keyboard on its own
++// account, and the recorded foreign surface may simply be stale.
++TEST_P(WaylandEmbeddedWindowTest, ActivateDoesNotStealFromAToplevel) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto embedded = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(embedded);
++
++  // window_ is the fixture's ordinary toplevel.
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  manager_->SetKeyboardFocusedWindow(window_.get());
++
++  embedded->Activate();
++  task_environment_.RunUntilIdle();
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), window_.get());
++}
++
++// With the keyboard somewhere else entirely there is nothing to take over,
++// and activating must not pull it in. Requires a keyboard to exist: without
++// one the gate does not apply at all, which the next test covers.
++TEST_P(WaylandEmbeddedWindowTest, ActivateIgnoresAnUnrelatedForeignSurface) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto embedded = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(embedded);
++
++  manager_->SetKeyboardFocusedForeignSurface(nullptr);
++  manager_->SetKeyboardFocusedWindow(nullptr);
++
++  embedded->Activate();
++  task_environment_.RunUntilIdle();
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), nullptr);
++}
++
++// Deactivating gives up the routing entry too. Clearing only the focus would
++// hand the keyboard straight back on the next enter -- the user moving the
++// pointer out of the host window and in again -- to a browser the embedder has
++// since deactivated or hidden.
++TEST_P(WaylandEmbeddedWindowTest, DeactivateReleasesTheRoutingEntry) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto embedded = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(embedded);
++
++  embedded->Activate();
++  task_environment_.RunUntilIdle();
++  ASSERT_EQ(wl::KeyboardWindowFromWlSurface(foreign_surface_), embedded.get());
++
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  manager_->SetKeyboardFocusedWindow(embedded.get());
++
++  embedded->Deactivate();
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), nullptr);
++  EXPECT_EQ(manager_->GetCurrentTextInputFocusedWindow(), nullptr);
++  // The next enter has nothing to resolve to.
++  EXPECT_EQ(wl::KeyboardWindowFromWlSurface(foreign_surface_), nullptr);
++}
++
++// A panel being torn down must not take routing away from a sibling that has
++// since claimed it.
++TEST_P(WaylandEmbeddedWindowTest, DestroyingASiblingKeepsTheOwnersEntry) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  MockWaylandPlatformWindowDelegate delegate_a(connection_.get());
++  MockWaylandPlatformWindowDelegate delegate_b(connection_.get());
++  auto first = CreateEmbedded(&delegate_a, parent);
++  auto second = CreateEmbedded(&delegate_b, parent);
++  ASSERT_TRUE(first);
++  ASSERT_TRUE(second);
++
++  second->Activate();
++  task_environment_.RunUntilIdle();
++  ASSERT_EQ(wl::KeyboardWindowFromWlSurface(foreign_surface_), second.get());
++
++  first.reset();
++  EXPECT_EQ(wl::KeyboardWindowFromWlSurface(foreign_surface_), second.get());
++}
++
++// An embedder whose toolkit does not expose its xdg_surface still gets a
++// working browser. Popups are not lost -- they fall back to a subsurface, which
++// the next test covers -- but this used to abort the host process on the first
++// <select>, because XdgPopup::Initialize() CHECKs.
++TEST_P(WaylandEmbeddedWindowTest, NoXdgSurfaceLeavesTheWindowUsable) {
++  const gfx::AcceleratedWidget parent =
++      RegisterForeignParent(/*with_xdg_surface=*/false);
++  ASSERT_NE(parent, gfx::kNullAcceleratedWidget);
++
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  auto* embedded = window->AsWaylandEmbeddedWindow();
++  ASSERT_TRUE(embedded);
++  EXPECT_EQ(embedded->foreign_xdg_surface(), nullptr);
++
++  // Still a usable window: it takes bounds and reports itself normally.
++  EXPECT_EQ(window->GetBoundsInDIP(), kPanelBounds);
++  EXPECT_EQ(wl::KeyboardWindowFromWlSurface(foreign_surface_), window.get());
++}
++
++// Without an xdg_surface a menu cannot be an xdg_popup, and it must not fail
++// either: views destroys the widget inside Widget::Show() when window creation
++// returns null, and HandleWidgetDestroyed() CHECKs on that. It falls back to a
++// subsurface instead.
++TEST_P(WaylandEmbeddedWindowTest,
++       MenuWithoutAnXdgSurfaceFallsBackToASubsurface) {
++  const gfx::AcceleratedWidget parent =
++      RegisterForeignParent(/*with_xdg_surface=*/false);
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  MockWaylandPlatformWindowDelegate menu_delegate(connection_.get());
++  auto menu = CreateWaylandWindowWithParams(
++      PlatformWindowType::kMenu, gfx::Rect(0, 0, 80, 90), &menu_delegate,
++      window->GetWidget());
++
++  // The point is that this exists at all.
++  ASSERT_TRUE(menu);
++  EXPECT_TRUE(menu->AsWaylandBubble());
++  EXPECT_EQ(menu->AsWaylandPopup(), nullptr);
++}
++
++// With one, the ordinary xdg_popup path is still taken.
++TEST_P(WaylandEmbeddedWindowTest, MenuWithAnXdgSurfaceIsStillAnXdgPopup) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  MockWaylandPlatformWindowDelegate menu_delegate(connection_.get());
++  auto menu = CreateWaylandWindowWithParams(
++      PlatformWindowType::kMenu, gfx::Rect(0, 0, 80, 90), &menu_delegate,
++      window->GetWidget());
++  ASSERT_TRUE(menu);
++  EXPECT_TRUE(menu->AsWaylandPopup());
++  EXPECT_EQ(menu->AsWaylandBubble(), nullptr);
++}
++
++// The two coordinate spaces an embedded window has children in, which are not
++// the same and were conflated once.
++//
++// An xdg_popup hangs off the *embedding application's* xdg_surface, so it is
++// measured in that surface's space -- the same space the embedded window's own
++// bounds are already in, so its origin must not be subtracted. A bubble is a
++// wl_subsurface of the embedded window itself, so its position is relative to
++// that window and the origin must be subtracted as usual.
++//
++// Getting this wrong in either direction displaces the menu by the offset of
++// the browser within the host window.
++TEST_P(WaylandEmbeddedWindowTest, PopupAndBubbleUseDifferentCoordinateSpaces) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++  ASSERT_EQ(window->GetBoundsInDIP().origin(), kPanelBounds.origin());
++  ASSERT_NE(kPanelBounds.origin(), gfx::Point());
++
++  // Parented at the embedded window rather than at the embedder's surface, so
++  // this really is a child of the browser and not a second embedded window.
++  constexpr gfx::Rect kMenuBounds(40, 60, 80, 90);
++  MockWaylandPlatformWindowDelegate menu_delegate(connection_.get());
++  auto menu =
++      CreateWaylandWindowWithParams(PlatformWindowType::kMenu, kMenuBounds,
++                                    &menu_delegate, window->GetWidget());
++  ASSERT_TRUE(menu);
++  ASSERT_TRUE(menu->AsWaylandPopup());
++
++  // Anchored on the embedder's xdg_surface: unchanged.
++  EXPECT_EQ(wl::TranslateWindowBoundsToXdgParentDIP(menu.get(), window.get()),
++            kMenuBounds);
++
++  // A subsurface of the embedded window would be relative to it.
++  EXPECT_EQ(
++      wl::TranslateWindowBoundsToParentDIP(menu.get(), window.get()),
++      gfx::Rect(kMenuBounds.origin() - kPanelBounds.origin().OffsetFromOrigin(),
++                kMenuBounds.size()));
++}
++
++// A browser added to a host that is already on a fractional-scale output has
++// nothing to inherit its scale from: an embedded window has no parent
++// WaylandWindow, and there is no way to ask which output the embedding
++// application's surface is on. WaylandWindow::Initialize() then resolves the
++// unset scale to 1.0, and the new browser renders at 1x and is upscaled --
++// blurry until the window is dragged to another output and back, because only
++// a real change produces a preferred_scale event.
++//
++// A sibling already embedded in the same surface is on the same output by
++// construction, so it is the seed.
++TEST_P(WaylandEmbeddedWindowTest, ANewSiblingInheritsTheScaleOfTheExistingOne) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  MockWaylandPlatformWindowDelegate delegate_a(connection_.get());
++  auto first = CreateEmbedded(&delegate_a, parent);
++  ASSERT_TRUE(first);
++  ASSERT_TRUE(first->root_surface());
++
++  // Stand in for wp_fractional_scale_v1.preferred_scale having arrived for the
++  // window that was already there.
++  constexpr float kFractional = 1.25f;
++  first->root_surface()->set_preferred_scale_factor_for_testing(kFractional);
++  ASSERT_EQ(first->GetPreferredScaleFactor(), kFractional);
++
++  MockWaylandPlatformWindowDelegate delegate_b(connection_.get());
++  auto second = CreateEmbedded(&delegate_b, parent);
++  ASSERT_TRUE(second);
++
++  EXPECT_EQ(second->GetPreferredScaleFactor(), kFractional);
++
++  // And the seed has to reach the window, not just sit in the surface's cache.
++  // WaylandWindow::Initialize() takes state->window_scale as final, so
++  // OnInitialize() reads the inherited value back; without that the new browser
++  // renders at the primary display's scale no matter what the sibling knows.
++  EXPECT_EQ(second->applied_state().window_scale, kFractional);
++
++  // And a window embedded in some other surface must not inherit it.
++  auto* other_surface = wl_compositor_create_surface(connection_->compositor());
++  ASSERT_TRUE(other_surface);
++  const gfx::AcceleratedWidget other_parent =
++      RegisterForeignWaylandSurface(other_surface, nullptr);
++  MockWaylandPlatformWindowDelegate delegate_c(connection_.get());
++  auto unrelated = CreateEmbedded(&delegate_c, other_parent);
++  ASSERT_TRUE(unrelated);
++  EXPECT_EQ(unrelated->GetPreferredScaleFactor(), std::nullopt);
++
++  unrelated.reset();
++  UnregisterForeignWaylandSurface(other_parent);
++  wl_surface_destroy(other_surface);
++}
++
++// The seat is the authority on activation, not the embedder's request. A
++// browser created while the host has no focus is inactive; when
++// wl_keyboard.enter later names the embedder's surface, the manager moves the
++// keyboard here and activation has to follow -- otherwise the browser takes
++// keys while views believes it inactive, and the input method never gets
++// OnFocus.
++TEST_P(WaylandEmbeddedWindowTest, KeyboardEnterActivatesWithoutAnyRequest) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++  ASSERT_FALSE(window->IsActive());
++
++  // What WaylandKeyboard::OnEnter leads to for the embedder's surface.
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  EXPECT_CALL(delegate, OnActivationChanged(true)).Times(1);
++  manager_->SetKeyboardFocusedWindow(window.get());
++  task_environment_.RunUntilIdle();
++  ::testing::Mock::VerifyAndClearExpectations(&delegate);
++  EXPECT_TRUE(window->IsActive());
++}
++
++// And wl_keyboard.leave has to deactivate it, or the browser stays active in
++// views after the whole application lost focus.
++TEST_P(WaylandEmbeddedWindowTest, KeyboardLeaveDeactivates) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  manager_->SetKeyboardFocusedWindow(window.get());
++  task_environment_.RunUntilIdle();
++  ASSERT_TRUE(window->IsActive());
++
++  EXPECT_CALL(delegate, OnActivationChanged(false)).Times(1);
++  manager_->SetKeyboardFocusedForeignSurface(nullptr);
++  manager_->SetKeyboardFocusedWindow(nullptr);
++  task_environment_.RunUntilIdle();
++  ::testing::Mock::VerifyAndClearExpectations(&delegate);
++  EXPECT_FALSE(window->IsActive());
++}
++
++// A browser that already holds the keyboard because enter put it there, and is
++// then activated by the embedder, must not be left unreported. This was the
++// gap: Activate() saw the focus already in place and returned without telling
++// views anything.
++TEST_P(WaylandEmbeddedWindowTest, ActivatingAnAlreadyFocusedWindowReports) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  // Focus arrives without any activation notification, the way it would if the
++  // manager had no embedded-window handling at all.
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  window->AsWaylandEmbeddedWindow()->Deactivate();
++  manager_->SetKeyboardFocusedWindow(nullptr);
++  manager_->SetEmbeddedWindowForForeignSurface(foreign_surface_, window.get());
++  ASSERT_FALSE(window->IsActive());
++
++  EXPECT_CALL(delegate, OnActivationChanged(true)).Times(1);
++  window->Activate();
++  task_environment_.RunUntilIdle();
++  EXPECT_TRUE(window->IsActive());
++}
++
++// On a seat with no keyboard -- touch only, or a virtual keyboard behind an
++// input method -- wl_keyboard.enter never arrives, so the recorded foreign
++// surface stays null forever. Gating on it would make every Activate() return
++// early and leave the browser permanently inactive. The embedder's request is
++// the authority in that case, and it is the only one there is.
++TEST_P(WaylandEmbeddedWindowTest, ActivationWorksWithNoKeyboardOnTheSeat) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  // Deliberately no PlugKeyboard().
++  ASSERT_FALSE(connection_->IsKeyboardAvailable());
++
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++  ASSERT_FALSE(window->IsActive());
++
++  EXPECT_CALL(delegate, OnActivationChanged(true)).Times(1);
++  window->Activate();
++  task_environment_.RunUntilIdle();
++  ::testing::Mock::VerifyAndClearExpectations(&delegate);
++  EXPECT_TRUE(window->IsActive());
++
++  EXPECT_CALL(delegate, OnActivationChanged(false)).Times(1);
++  window->Deactivate();
++  task_environment_.RunUntilIdle();
++  EXPECT_FALSE(window->IsActive());
++}
++
++// With no keyboard on the seat, zwp_text_input_v3 is what routes text, and a
++// toplevel holding that focus owns it exactly as legitimately as a keyboard
++// holder would. Checking only the keyboard -- which is null here by definition
++// -- would let an embedded window take the input method away from it while the
++// compositor kept delivering there.
++TEST_P(WaylandEmbeddedWindowTest,
++       NoKeyboardDoesNotStealTextInputFromAToplevel) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  ASSERT_FALSE(connection_->IsKeyboardAvailable());
++
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto embedded = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(embedded);
++
++  // window_ is the fixture's ordinary toplevel, focused by the compositor.
++  manager_->SetTextInputFocusedWindow(window_.get());
++  ASSERT_EQ(manager_->GetCurrentTextInputFocusedWindow(), window_.get());
++
++  EXPECT_CALL(delegate, OnActivationChanged(::testing::_)).Times(0);
++  embedded->Activate();
++  task_environment_.RunUntilIdle();
++
++  EXPECT_EQ(manager_->GetCurrentTextInputFocusedWindow(), window_.get());
++  EXPECT_FALSE(embedded->IsActive());
++}
++
++// Without a keyboard the window must not record a keyboard focus of its own.
++// Nothing on such a seat ever clears one, and the ownership check reads it back
++// as this window legitimately holding focus -- so a later Activate() would
++// overwrite a text-input focus the compositor had since handed to a toplevel.
++TEST_P(WaylandEmbeddedWindowTest, NoKeyboardLeavesNoStaleFocusBehind) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  ASSERT_FALSE(connection_->IsKeyboardAvailable());
++
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto embedded = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(embedded);
++
++  embedded->Activate();
++  task_environment_.RunUntilIdle();
++  ASSERT_TRUE(embedded->IsActive());
++  // No keyboard exists, so no keyboard focus may have been synthesised.
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), nullptr);
++
++  // The compositor now gives text input to a toplevel of this process.
++  manager_->SetTextInputFocusedWindow(window_.get());
++
++  embedded->Activate();
++  task_environment_.RunUntilIdle();
++  EXPECT_EQ(manager_->GetCurrentTextInputFocusedWindow(), window_.get());
++}
++
++// A request withdrawn before the posted task runs must not be carried out. A
++// host that deactivates or hides in the same turn of the loop would otherwise
++// see the browser hand focus back to itself a moment later.
++TEST_P(WaylandEmbeddedWindowTest, DeactivatingBeforeTheTaskRunsWins) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++
++  // No RunUntilIdle() between the two: that is the whole point.
++  window->Activate();
++  window->Deactivate();
++
++  EXPECT_CALL(delegate, OnActivationChanged(true)).Times(0);
++  task_environment_.RunUntilIdle();
++
++  EXPECT_FALSE(window->IsActive());
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), nullptr);
++}
++
++// The same for Hide(), which deactivates on the way down.
++TEST_P(WaylandEmbeddedWindowTest, HidingBeforeTheTaskRunsWins) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  window->Show(/*inactive=*/false);
++
++  window->Activate();
++  window->Hide();
++
++  EXPECT_CALL(delegate, OnActivationChanged(true)).Times(0);
++  task_environment_.RunUntilIdle();
++  EXPECT_FALSE(window->IsActive());
++}
++
++// A click has to move the focus before the events queued behind it are
++// dispatched, so it cannot go through the deferred path.
++TEST_P(WaylandEmbeddedWindowTest, ClickMovesFocusWithoutWaitingForATask) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate_a(connection_.get());
++  MockWaylandPlatformWindowDelegate delegate_b(connection_.get());
++  auto first = CreateEmbedded(&delegate_a, parent);
++  auto second = CreateEmbedded(&delegate_b, parent);
++  ASSERT_TRUE(first);
++  ASSERT_TRUE(second);
++
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  manager_->SetKeyboardFocusedWindow(first.get());
++  ASSERT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), first.get());
++
++  MouseEvent press(EventType::kMousePressed, gfx::Point(1, 1), gfx::Point(1, 1),
++                   base::TimeTicks::Now(), EF_LEFT_MOUSE_BUTTON,
++                   EF_LEFT_MOUSE_BUTTON);
++  second->DispatchEvent(&press);
++
++  // No RunUntilIdle(): a key in the same batch would be dispatched here.
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), second.get());
++}
++
++// A zwp_text_input_v3.enter naming the embedder's surface is what lets a
++// browser created afterwards claim the input method. The compositor does not
++// repeat that event, so without recording the surface the focus would be lost
++// for good -- the same problem the keyboard side already solved.
++TEST_P(WaylandEmbeddedWindowTest, TextInputEnterBeforeTheBrowserExistsIsKept) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  ASSERT_FALSE(connection_->IsKeyboardAvailable());
++
++  // The enter arrives while nothing is embedded yet, so it resolves to no
++  // window at all -- only the surface survives.
++  manager_->SetTextInputFocusedForeignSurface(foreign_surface_);
++  ASSERT_EQ(manager_->GetCurrentTextInputFocusedWindow(), nullptr);
++
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  window->Activate();
++  task_environment_.RunUntilIdle();
++  EXPECT_EQ(manager_->GetCurrentTextInputFocusedWindow(), window.get());
++}
++
++// And with no such event, the focus is not invented: text-input-v3 defines
++// enable against the surface an enter named, and a wl_keyboard.enter is a
++// different focus from a different event.
++TEST_P(WaylandEmbeddedWindowTest, KeyboardEnterIsNotEvidenceOfTextInputFocus) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  // Keyboard focus only. No text-input enter has ever named this surface.
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++
++  window->Activate();
++  task_environment_.RunUntilIdle();
++
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), window.get());
++  EXPECT_EQ(manager_->GetCurrentTextInputFocusedWindow(), nullptr);
++}
++
++// Ozone-level routing is only half of activation: views keeps its own notion of
++// which widget is active, fed only by the delegate. Without this call
++// Widget::IsActive() stays wrong, the FocusController is never driven, and
++// InputMethod::OnFocus/OnBlur never arrive -- the last of which is what an IME
++// depends on.
++TEST_P(WaylandEmbeddedWindowTest, ActivationReachesTheDelegate) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++  ASSERT_FALSE(window->IsActive());
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++
++  EXPECT_CALL(delegate, OnActivationChanged(true)).Times(1);
++  window->Activate();
++  task_environment_.RunUntilIdle();
++  ::testing::Mock::VerifyAndClearExpectations(&delegate);
++  EXPECT_TRUE(window->IsActive());
++
++  EXPECT_CALL(delegate, OnActivationChanged(false)).Times(1);
++  window->Deactivate();
++  task_environment_.RunUntilIdle();
++  ::testing::Mock::VerifyAndClearExpectations(&delegate);
++  EXPECT_FALSE(window->IsActive());
++}
++
++// Redundant calls must not produce spurious notifications: views treats each
++// one as a real activation change and restores focus on the back of it.
++TEST_P(WaylandEmbeddedWindowTest, RepeatedActivationIsNotReported) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++
++  EXPECT_CALL(delegate, OnActivationChanged(true)).Times(1);
++  window->Activate();
++  task_environment_.RunUntilIdle();
++  window->Activate();
++  task_environment_.RunUntilIdle();
++  window->Activate();
++  task_environment_.RunUntilIdle();
++  ::testing::Mock::VerifyAndClearExpectations(&delegate);
++}
++
++// Activating a sibling has to deactivate the other by itself. The click path
++// only calls Activate() on the window that was clicked; nothing calls
++// Deactivate() on the one losing focus, and SetKeyboardFocusedWindow() delivers
++// OnKeyboardFocusChanged() without touching activation. Calling Deactivate()
++// here first would test the embedder's manners rather than the code.
++TEST_P(WaylandEmbeddedWindowTest, ActivatingASiblingDeactivatesTheOther) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate_a(connection_.get());
++  MockWaylandPlatformWindowDelegate delegate_b(connection_.get());
++  auto first = CreateEmbedded(&delegate_a, parent);
++  auto second = CreateEmbedded(&delegate_b, parent);
++  ASSERT_TRUE(first);
++  ASSERT_TRUE(second);
++
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  first->Activate();
++  task_environment_.RunUntilIdle();
++  ASSERT_TRUE(first->IsActive());
++
++  EXPECT_CALL(delegate_a, OnActivationChanged(false)).Times(1);
++  EXPECT_CALL(delegate_b, OnActivationChanged(true)).Times(1);
++  second->Activate();
++  task_environment_.RunUntilIdle();
++
++  EXPECT_FALSE(first->IsActive());
++  EXPECT_TRUE(second->IsActive());
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), second.get());
++}
++
++// Widget::Show() calls Activate() on every browser it shows. When the
++// embedder's surface does not hold the seat's keyboard focus, that request
++// cannot be honoured, and reporting it as activation would tell views that a
++// browser is focused while the keys are going to another application.
++TEST_P(WaylandEmbeddedWindowTest, ActivationIsNotClaimedWithoutKeyboardFocus) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  // No wl_keyboard.enter has named the embedder's surface.
++  manager_->SetKeyboardFocusedForeignSurface(nullptr);
++
++  EXPECT_CALL(delegate, OnActivationChanged(::testing::_)).Times(0);
++  window->Activate();
++  task_environment_.RunUntilIdle();
++  EXPECT_FALSE(window->IsActive());
++}
++
++// Nor when the keyboard is legitimately on a Chromium toplevel of this
++// process: refusing to take the focus and reporting activation anyway is the
++// same inconsistency seen from the other side.
++TEST_P(WaylandEmbeddedWindowTest, RefusingToStealDoesNotReportActivation) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  PlugKeyboard();
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto embedded = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(embedded);
++
++  manager_->SetKeyboardFocusedForeignSurface(foreign_surface_);
++  manager_->SetKeyboardFocusedWindow(window_.get());
++
++  EXPECT_CALL(delegate, OnActivationChanged(::testing::_)).Times(0);
++  embedded->Activate();
++  task_environment_.RunUntilIdle();
++
++  EXPECT_FALSE(embedded->IsActive());
++  EXPECT_EQ(manager_->GetCurrentKeyboardFocusedWindow(), window_.get());
++}
++
++// A separate fixture because advertising text-input-v3 changes what
++// UpdateActivationState() derives from: with it available, the keyboardless
++// tests above would take the text-input tier instead of the embedder-request
++// one, and would stop testing what they were written for.
++class WaylandEmbeddedWindowTextInputTest : public WaylandEmbeddedWindowTest {};
++
++// The same thing again, but driven through the protocol instead of by writing
++// the manager state directly: the compositor sends zwp_text_input_v3.enter for
++// the embedder's surface while nothing is embedded in it yet.
++TEST_P(WaylandEmbeddedWindowTextInputTest, TextInputEnterArrivesThroughTheProtocol) {
++  const gfx::AcceleratedWidget parent = RegisterForeignParent();
++  SendTextInputEnterForForeignSurface();
++
++  // It resolved to no window -- there was none -- but the surface was kept.
++  EXPECT_EQ(manager_->GetCurrentTextInputFocusedWindow(), nullptr);
++  ASSERT_EQ(manager_->text_input_focused_foreign_surface(),
++            foreign_surface_.get());
++
++  MockWaylandPlatformWindowDelegate delegate(connection_.get());
++  auto window = CreateEmbedded(&delegate, parent);
++  ASSERT_TRUE(window);
++
++  window->Activate();
++  task_environment_.RunUntilIdle();
++  EXPECT_EQ(manager_->GetCurrentTextInputFocusedWindow(), window.get());
++}
++
++INSTANTIATE_TEST_SUITE_P(XdgVersionStableTest,
++                         WaylandEmbeddedWindowTest,
++                         Values(wl::ServerConfig{}));
++
++INSTANTIATE_TEST_SUITE_P(
++    TextInputV3Test,
++    WaylandEmbeddedWindowTextInputTest,
++    Values(wl::ServerConfig{.text_input_type = wl::ZwpTextInputType::kV3}));
++
++}  // namespace ui
+diff --git ui/ozone/platform/wayland/host/wayland_keyboard.cc ui/ozone/platform/wayland/host/wayland_keyboard.cc
+index e091a743368dbc797c1b0ead7879384397cc49bd..f763909594266204191135b5ba3caf25a3ee7ff5 100644
+--- ui/ozone/platform/wayland/host/wayland_keyboard.cc
++++ ui/ozone/platform/wayland/host/wayland_keyboard.cc
+@@ -34,6 +34,8 @@
+ #include "ui/ozone/platform/wayland/host/wayland_seat.h"
+ #include "ui/ozone/platform/wayland/host/wayland_serial_tracker.h"
+ #include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_window_manager.h"
++#include "ui/ozone/platform/wayland/wayland_embedder.h"
+ #include "ui/ozone/public/platform_keyboard_hook.h"
+ 
+ #if BUILDFLAG(USE_XKBCOMMON)
+@@ -273,9 +275,20 @@ void WaylandKeyboard::OnEnter(void* data,
+                               uint32_t serial,
+                               wl_surface* surface,
+                               wl_array* keys) {
++  auto* self = static_cast<WaylandKeyboard*>(data);
++
++  // Record the surface itself, not just the window it resolves to. When the
++  // surface belongs to an embedding application this is the only event that
++  // names it, and an embedded window created or activated later has no other
++  // way to tell that the keys are addressed to its embedder. See
++  // WaylandWindowManager::SetKeyboardFocusedForeignSurface().
++  if (surface && !ui::ChromiumSurfaceFor(surface)) {
++    self->connection_->window_manager()->SetKeyboardFocusedForeignSurface(
++        surface);
++  }
++
+   // wl_surface might have been destroyed by this time.
+-  if (auto* window = wl::RootWindowFromWlSurface(surface)) {
+-    auto* self = static_cast<WaylandKeyboard*>(data);
++  if (auto* window = wl::KeyboardWindowFromWlSurface(surface)) {
+     self->delegate_->OnKeyboardFocusChanged(window, /*focused=*/true);
+   }
+ }
+@@ -287,7 +300,13 @@ void WaylandKeyboard::OnLeave(void* data,
+                               wl_surface* surface) {
+   // wl_surface might have been destroyed by this time.
+   auto* self = static_cast<WaylandKeyboard*>(data);
+-  if (auto* window = wl::RootWindowFromWlSurface(surface))
++  if (surface &&
++      self->connection_->window_manager()
++              ->keyboard_focused_foreign_surface() == surface) {
++    self->connection_->window_manager()->SetKeyboardFocusedForeignSurface(
++        nullptr);
++  }
++  if (auto* window = wl::KeyboardWindowFromWlSurface(surface))
+     self->delegate_->OnKeyboardFocusChanged(window, /*focused=*/false);
+ 
+   // Upon window focus lose, reset modifier state.
+diff --git ui/ozone/platform/wayland/host/wayland_popup.cc ui/ozone/platform/wayland/host/wayland_popup.cc
+index 8b5b03e7579b43b496909f1fc0a909ab9f614f60..568dcc54b8eb3a7eeb4231a594dc422280406b17 100644
+--- ui/ozone/platform/wayland/host/wayland_popup.cc
++++ ui/ozone/platform/wayland/host/wayland_popup.cc
+@@ -34,8 +34,12 @@ WaylandPopup::WaylandPopup(PlatformWindowDelegate* delegate,
+   // TODO(crbug.com/330384470): Whether the popup appear depends on whether
+   // anchor point is outside of the parent xdg_surface. On Mutter the popup will
+   // not show when outside.
+-  LOG_IF(WARNING,
+-         !parent->AsWaylandToplevelWindow() && !parent->AsWaylandPopup())
++  // An embedded window is not a bubble: it anchors popups on the embedding
++  // application's xdg_surface, which is a legitimate xdg parent, so it does not
++  // carry the uncertainty this warns about.
++  LOG_IF(WARNING, !parent->AsWaylandToplevelWindow() &&
++                      !parent->AsWaylandPopup() &&
++                      !parent->AsWaylandEmbeddedWindow())
+       << "Popup's parent is a bubble. Wayland shell popup is not guaranteed to "
+          "show up.";
+ }
+@@ -61,7 +65,7 @@ bool WaylandPopup::CreateShellPopup() {
+   }
+ 
+   auto bounds_dip =
+-      wl::TranslateWindowBoundsToParentDIP(this, xdg_parent_window);
++      wl::TranslateWindowBoundsToXdgParentDIP(this, xdg_parent_window);
+   bounds_dip.Inset(delegate()->CalculateInsetsInDIP(GetPlatformWindowState()));
+ 
+   // At this point, both `bounds` and `anchor_rect` parameters here are in
+@@ -77,9 +81,21 @@ bool WaylandPopup::CreateShellPopup() {
+   if (params.anchor.has_value()) {
+     // The anchor rectangle must be relative to the window geometry, rather
+     // than the root surface origin. See https://crbug.com/1292486.
++    //
++    // An embedded window is the exception, for the same reason it is one in
++    // TranslateWindowBoundsToXdgParentDIP(): the popup hangs off the embedding
++    // application's xdg_surface, so it is already measured in that surface's
++    // space. Subtracting the embedded window's own origin would shift the
++    // anchor by the offset of the browser within the host window, and only for
++    // the popups that carry an anchor rectangle -- menus would land in a
++    // different place than <select> dropdowns.
++    const gfx::Rect parent_bounds_dip =
++        xdg_parent_window->AsWaylandEmbeddedWindow()
++            ? gfx::Rect(xdg_parent_window->GetBoundsInDIP().size())
++            : xdg_parent_window->GetBoundsInDIP();
+     gfx::Rect anchor_rect(
+-        wl::TranslateBoundsToParentCoordinates(
+-            params.anchor->anchor_rect, xdg_parent_window->GetBoundsInDIP()) -
++        wl::TranslateBoundsToParentCoordinates(params.anchor->anchor_rect,
++                                               parent_bounds_dip) -
+         xdg_parent_window->GetWindowGeometryOffsetInDIP());
+ 
+     // Convert `anchor_rect` to Wayland coordinates space.
+@@ -190,7 +206,7 @@ void WaylandPopup::SetBoundsInDIP(const gfx::Rect& bounds_dip) {
+   // the initialization. See WaylandPopup::CreateShellPopup.
+   if (xdg_popup_ && old_bounds_dip != bounds_dip) {
+     auto bounds_dip_in_parent =
+-        wl::TranslateWindowBoundsToParentDIP(this, xdg_parent_window);
++        wl::TranslateWindowBoundsToXdgParentDIP(this, xdg_parent_window);
+     bounds_dip_in_parent.Inset(
+         delegate()->CalculateInsetsInDIP(GetPlatformWindowState()));
+ 
+diff --git ui/ozone/platform/wayland/host/wayland_surface.cc ui/ozone/platform/wayland/host/wayland_surface.cc
+index 0efd9ed7520c8e11f1c002b7bb087dfbc4db5ab6..6fd4e00749c95f4ae16d0b05f2f81a3288fce770 100644
+--- ui/ozone/platform/wayland/host/wayland_surface.cc
++++ ui/ozone/platform/wayland/host/wayland_surface.cc
+@@ -37,13 +37,16 @@
+ #include "ui/ozone/platform/wayland/host/wayland_buffer_handle.h"
+ #include "ui/ozone/platform/wayland/host/wayland_buffer_manager_host.h"
+ #include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_embedded_window.h"
+ #include "ui/ozone/platform/wayland/host/wayland_output.h"
+ #include "ui/ozone/platform/wayland/host/wayland_output_manager.h"
+ #include "ui/ozone/platform/wayland/host/wayland_subsurface.h"
+ #include "ui/ozone/platform/wayland/host/wayland_syncobj_timeline.h"
+ #include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_window_manager.h"
+ #include "ui/ozone/platform/wayland/host/wayland_wp_color_management_surface.h"
+ #include "ui/ozone/platform/wayland/host/wayland_wp_color_manager.h"
++#include "ui/ozone/platform/wayland/wayland_embedder.h"
+ 
+ namespace ui {
+ 
+@@ -100,10 +103,31 @@ WaylandSurface::WaylandSurface(WaylandConnection* connection,
+   if (root_window_ && root_window_->parent_window()) {
+     preferred_scale_factor_ =
+         root_window_->parent_window()->GetPreferredScaleFactor();
++  } else if (root_window_ && root_window_->AsWaylandEmbeddedWindow()) {
++    // An embedded window has no parent WaylandWindow to inherit from, and no
++    // way to ask which output the embedding application's surface is on. A
++    // sibling already attached to that same surface is the best guess
++    // available: it has already been told a scale by the compositor, and it is
++    // almost always on the same output. Not necessarily -- a wl_surface may
++    // span zero or more outputs, so a host straddling two monitors can have
++    // subsurfaces on different ones -- which is why this is a seed and not an
++    // answer. preferred_scale corrects it as soon as the compositor sends one.
++    //
++    // Without this the scale stays unset, WaylandWindow::Initialize() resolves
++    // that to 1.0, and a browser added while the host sits on a fractional
++    // output renders at 1x and is upscaled -- blurry until the window is
++    // dragged to another output and back, since only an actual change produces
++    // a wp_fractional_scale_v1.preferred_scale event.
++    preferred_scale_factor_ =
++        connection_->window_manager()->GetPreferredScaleForForeignSurface(
++            root_window_->AsWaylandEmbeddedWindow()->parent_surface(),
++            root_window_);
+   }
+ }
+ 
+-WaylandSurface::~WaylandSurface() = default;
++WaylandSurface::~WaylandSurface() {
++  UnregisterChromiumSurface(surface_.get());
++}
+ 
+ void WaylandSurface::RequestExplicitRelease(ExplicitReleaseCallback callback) {
+   DCHECK(!next_explicit_release_request_);
+@@ -128,6 +152,10 @@ bool WaylandSurface::Initialize() {
+   // WaylandDataDragController.
+   if (!root_window() || root_window()->root_surface() == this) {
+     wl_surface_add_listener(surface_.get(), &kSurfaceListener, this);
++    // Registered under exactly the same condition that used to set the user
++    // data this replaces, so that RootWindowFromWlSurface() keeps resolving the
++    // same set of surfaces and no others.
++    RegisterChromiumSurface(surface_.get(), this);
+   }
+ 
+   if (connection_->fractional_scale_manager_v1()) {
+@@ -501,6 +529,17 @@ wl::Object<wl_subsurface> WaylandSurface::CreateSubsurface(
+   return subsurface;
+ }
+ 
++wl::Object<wl_subsurface> WaylandSurface::CreateSubsurfaceForForeignParent(
++    wl_surface* parent) {
++  CHECK(parent);
++  wl_subcompositor* subcompositor = connection_->subcompositor();
++  if (!subcompositor) {
++    return {};
++  }
++  return wl::Object<wl_subsurface>(
++      wl_subcompositor_get_subsurface(subcompositor, surface_.get(), parent));
++}
++
+ std::optional<bool> WaylandSurface::ApplyPendingState() {
+   DCHECK(!apply_state_immediately_);
+   bool needs_commit = false;
+diff --git ui/ozone/platform/wayland/host/wayland_surface.h ui/ozone/platform/wayland/host/wayland_surface.h
+index 3c49265ef24a01d03eb2dce4a9505e3c97a69c94..3db8e8349a82d23feea93cfcb9b7c4e32bcd42cc 100644
+--- ui/ozone/platform/wayland/host/wayland_surface.h
++++ ui/ozone/platform/wayland/host/wayland_surface.h
+@@ -189,6 +189,14 @@ class WaylandSurface {
+   // |parent|. Callers take ownership of the wl_subsurface.
+   wl::Object<wl_subsurface> CreateSubsurface(WaylandSurface* parent);
+ 
++  // Same, but parented to a wl_surface that belongs to an embedding
++  // application rather than to Chromium. |parent| must come from the same
++  // wl_display as this surface; wl_subcompositor_get_subsurface() rejects
++  // surfaces from a different connection. Returns null if the subcompositor is
++  // unavailable. See WaylandEmbeddedWindow.
++  wl::Object<wl_subsurface> CreateSubsurfaceForForeignParent(
++      wl_surface* parent);
++
+   // When display is removed, the WaylandOutput from `entered_outputs_` should
+   // be removed.
+   void RemoveEnteredOutput(uint32_t id);
+@@ -221,6 +229,12 @@ class WaylandSurface {
+     return preferred_scale_factor_;
+   }
+ 
++  // Stands in for wp_fractional_scale_v1.preferred_scale, which a test server
++  // does not send.
++  void set_preferred_scale_factor_for_testing(float scale) {
++    preferred_scale_factor_ = scale;
++  }
++
+   // Some states do not take effect if the surface commit has no buffer.
+   // E.g. `xdg_surface.set_window_geometry`
+   bool has_buffer() const { return state_.buffer_id; }
+diff --git ui/ozone/platform/wayland/host/wayland_window.cc ui/ozone/platform/wayland/host/wayland_window.cc
+index dcd3ff3545689f7566b3e2ff950865cf799bf939..b2d95ae602910df542339917ea088f0c4e2efd9c 100644
+--- ui/ozone/platform/wayland/host/wayland_window.cc
++++ ui/ozone/platform/wayland/host/wayland_window.cc
+@@ -1068,8 +1068,14 @@ WaylandWindow* WaylandWindow::GetTopMostChildWindow() {
+ 
+ WaylandWindow* WaylandWindow::GetXdgParentWindow() {
+   auto* xdg_parent_window = parent_window();
++  // An embedded window has no xdg_surface of its own, but it borrows the
++  // embedding application's, so it can stand in as an xdg parent. Without this
++  // the walk runs off the end -- an embedded window has no parent WaylandWindow
++  // at all -- and every menu, tooltip and <select> dropdown silently fails to
++  // open.
+   while (xdg_parent_window && !xdg_parent_window->AsWaylandToplevelWindow() &&
+-         !xdg_parent_window->AsWaylandPopup()) {
++         !xdg_parent_window->AsWaylandPopup() &&
++         !xdg_parent_window->AsWaylandEmbeddedWindow()) {
+     xdg_parent_window = xdg_parent_window->parent_window();
+   }
+   return xdg_parent_window;
+@@ -1088,6 +1094,10 @@ bool WaylandWindow::IsSuspended() const {
+   return false;
+ }
+ 
++WaylandEmbeddedWindow* WaylandWindow::AsWaylandEmbeddedWindow() {
++  return nullptr;
++}
++
+ WaylandBubble* WaylandWindow::AsWaylandBubble() {
+   return nullptr;
+ }
+diff --git ui/ozone/platform/wayland/host/wayland_window.h ui/ozone/platform/wayland/host/wayland_window.h
+index 7d82e02ad1b7ab23b006e1a25a0283a49b425159..4bd8e4032be5baf4cc98e437be3e54b9853b20f1 100644
+--- ui/ozone/platform/wayland/host/wayland_window.h
++++ ui/ozone/platform/wayland/host/wayland_window.h
+@@ -53,6 +53,7 @@ class BitmapCursor;
+ class OSExchangeData;
+ class WaylandAsyncCursor;
+ class WaylandBubble;
++class WaylandEmbeddedWindow;
+ class WaylandConnection;
+ class WaylandSubsurface;
+ class WaylandDataDragController;
+@@ -378,6 +379,7 @@ class WaylandWindow : public PlatformWindow,
+   // WaylandBubble, WaylandPopup or WaylandToplevelWindow, if |this| is
+   // of that type.
+   virtual WaylandBubble* AsWaylandBubble();
++  virtual WaylandEmbeddedWindow* AsWaylandEmbeddedWindow();
+   virtual WaylandPopup* AsWaylandPopup();
+   virtual WaylandToplevelWindow* AsWaylandToplevelWindow();
+ 
+diff --git ui/ozone/platform/wayland/host/wayland_window_factory.cc ui/ozone/platform/wayland/host/wayland_window_factory.cc
+index 333b59ff323502c3f5823398c2ac6a871c017d53..836ffda7781d8f021ad9ed5c97207b0c0f38345b 100644
+--- ui/ozone/platform/wayland/host/wayland_window_factory.cc
++++ ui/ozone/platform/wayland/host/wayland_window_factory.cc
+@@ -7,19 +7,62 @@
+ #include "base/logging.h"
+ #include "ui/ozone/platform/wayland/host/wayland_bubble.h"
+ #include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_embedded_window.h"
+ #include "ui/ozone/platform/wayland/host/wayland_popup.h"
+ #include "ui/ozone/platform/wayland/host/wayland_toplevel_window.h"
+ #include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_window_manager.h"
+ #include "ui/platform_window/platform_window_init_properties.h"
+ 
+ namespace ui {
+ 
++namespace {
++
++// True when a menu or tooltip parented at |parent| would find no xdg_surface to
++// anchor on: the chain reaches a window embedded in an application that did not
++// hand its own over. Walks the same way GetXdgParentWindow() does, but starting
++// at |parent| itself, which is where an embedded window sits.
++bool XdgParentIsUnavailable(WaylandWindow* parent) {
++  for (auto* window = parent; window; window = window->parent_window()) {
++    if (auto* embedded = window->AsWaylandEmbeddedWindow()) {
++      return !embedded->foreign_xdg_surface();
++    }
++    if (window->AsWaylandToplevelWindow() || window->AsWaylandPopup()) {
++      return false;
++    }
++  }
++  return false;
++}
++
++}  // namespace
++
+ // static
+ std::unique_ptr<WaylandWindow> WaylandWindow::Create(
+     PlatformWindowDelegate* delegate,
+     WaylandConnection* connection,
+     PlatformWindowInitProperties properties) {
+   std::unique_ptr<WaylandWindow> window;
++
++  // A parent widget naming a surface owned by an embedding application means
++  // the caller wants this window hosted inside that application's window,
++  // whatever PlatformWindowType views chose. views maps every Widget type it
++  // does not recognise to kPopup -- Widget::InitParams::TYPE_CONTROL, which is
++  // what an embedded browser uses, lands there -- so this cannot be decided
++  // from the type alone.
++  if (auto* foreign_surface = connection->window_manager()->GetForeignSurface(
++          properties.parent_widget)) {
++    auto embedded = std::make_unique<WaylandEmbeddedWindow>(
++        delegate, connection, foreign_surface,
++        connection->window_manager()->GetForeignXdgSurface(
++            properties.parent_widget));
++    // Correct the type views could not express. Left at kPopup, type() would
++    // lie to everything downstream that branches on it, for a window that is
++    // hosted content rather than a popup of anything.
++    properties.type = PlatformWindowType::kWindow;
++    return embedded->Initialize(std::move(properties)) ? std::move(embedded)
++                                                       : nullptr;
++  }
++
+   switch (properties.type) {
+     case PlatformWindowType::kPopup:
+     case PlatformWindowType::kBubble:
+@@ -40,7 +83,21 @@ std::unique_ptr<WaylandWindow> WaylandWindow::Create(
+     case PlatformWindowType::kMenu:
+       if (auto* parent = connection->window_manager()->GetWindow(
+               properties.parent_widget)) {
+-        window = std::make_unique<WaylandPopup>(delegate, connection, parent);
++        if (XdgParentIsUnavailable(parent)) {
++          // No xdg_surface anywhere up the chain, so xdg_surface.get_popup is
++          // not an option. Failing instead is not one either: views does not
++          // expect a widget to be destroyed inside Widget::Show(), and
++          // HandleWidgetDestroyed() CHECKs when it is.
++          //
++          // A wl_subsurface is what is left. It cannot extend past the host
++          // window or hold a grab, so a dropdown near the bottom edge is
++          // clipped and clicking outside does not dismiss it, but it renders
++          // where it is put -- which is the same trade WaylandBubble already
++          // makes.
++          window = std::make_unique<WaylandBubble>(delegate, connection, parent);
++        } else {
++          window = std::make_unique<WaylandPopup>(delegate, connection, parent);
++        }
+       } else {
+         DLOG(WARNING) << "Failed to determine parent for menu/tooltip window.";
+         window = std::make_unique<WaylandToplevelWindow>(delegate, connection);
+diff --git ui/ozone/platform/wayland/host/wayland_window_manager.cc ui/ozone/platform/wayland/host/wayland_window_manager.cc
+index 50db3bd8e6060d2e7326b33e1fb51cabbdf6abec..1f0a3832670b7083596411167d122c2a46c4c3a8 100644
+--- ui/ozone/platform/wayland/host/wayland_window_manager.cc
++++ ui/ozone/platform/wayland/host/wayland_window_manager.cc
+@@ -11,6 +11,7 @@
+ #include "ui/base/dragdrop/mojom/drag_drop_types.mojom.h"
+ #include "ui/display/display.h"
+ #include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_embedded_window.h"
+ #include "ui/ozone/platform/wayland/host/wayland_window.h"
+ #include "ui/ozone/platform/wayland/host/wayland_window_drag_controller.h"
+ #include "ui/ozone/platform/wayland/host/wayland_window_observer.h"
+@@ -21,6 +22,16 @@ namespace {
+ 
+ void UpdateToplevelActivation(WaylandWindow* old_focused_window,
+                               WaylandWindow* new_focused_window) {
++  // Taken before anything is notified. Every UpdateActivationState() below ends
++  // in PlatformWindowDelegate::OnActivationChanged(), which views documents may
++  // close the widget and destroy the platform window synchronously -- so
++  // deactivating a toplevel can invalidate the raw pointers this function was
++  // called with before the embedded windows below are reached.
++  auto weak_old =
++      old_focused_window ? old_focused_window->AsWeakPtr() : nullptr;
++  auto weak_new =
++      new_focused_window ? new_focused_window->AsWeakPtr() : nullptr;
++
+   auto* old_focused_toplevel_window =
+       old_focused_window
+           ? old_focused_window->GetRootParentWindow()->AsWaylandToplevelWindow()
+@@ -37,6 +48,19 @@ void UpdateToplevelActivation(WaylandWindow* old_focused_window,
+       focused_toplevel_window->UpdateActivationState();
+     }
+   }
++
++  // An embedded window is its own root and is not a toplevel, so the walk above
++  // skips it entirely. Its activation follows the same rule and has to be
++  // refreshed on both sides of the transition -- this is what makes
++  // wl_keyboard.enter and .leave drive it, rather than only an explicit
++  // Activate() from the embedder.
++  for (const auto& weak_window : {weak_old, weak_new}) {
++    if (weak_window) {
++      if (auto* embedded = weak_window->AsWaylandEmbeddedWindow()) {
++        embedded->UpdateActivationState();
++      }
++    }
++  }
+ }
+ 
+ void UpdateParentToplevelAcivationOnRemoval(WaylandWindow* window) {
+@@ -317,6 +341,104 @@ gfx::AcceleratedWidget WaylandWindowManager::AllocateAcceleratedWidget() {
+   return ++last_accelerated_widget_;
+ }
+ 
++gfx::AcceleratedWidget WaylandWindowManager::RegisterForeignSurface(
++    wl_surface* surface,
++    xdg_surface* xdg_surface) {
++  CHECK(surface);
++  const gfx::AcceleratedWidget widget = AllocateAcceleratedWidget();
++  foreign_surface_map_.emplace(widget, ForeignSurface{surface, xdg_surface});
++  return widget;
++}
++
++void WaylandWindowManager::UnregisterForeignSurface(
++    gfx::AcceleratedWidget widget) {
++  foreign_surface_map_.erase(widget);
++}
++
++wl_surface* WaylandWindowManager::GetForeignSurface(
++    gfx::AcceleratedWidget widget) const {
++  auto it = foreign_surface_map_.find(widget);
++  return it == foreign_surface_map_.end() ? nullptr : it->second.surface.get();
++}
++
++xdg_surface* WaylandWindowManager::GetForeignXdgSurface(
++    gfx::AcceleratedWidget widget) const {
++  auto it = foreign_surface_map_.find(widget);
++  return it == foreign_surface_map_.end() ? nullptr
++                                          : it->second.xdg_surface.get();
++}
++
++WaylandWindow* WaylandWindowManager::GetEmbeddedWindowForForeignSurface(
++    wl_surface* surface) const {
++  auto it = embedded_window_map_.find(surface);
++  return it == embedded_window_map_.end() ? nullptr : it->second.get();
++}
++
++void WaylandWindowManager::SetEmbeddedWindowForForeignSurface(
++    wl_surface* surface,
++    WaylandWindow* window) {
++  if (surface && window) {
++    embedded_window_map_[surface] = window;
++  }
++}
++
++void WaylandWindowManager::RemoveEmbeddedWindowForForeignSurface(
++    wl_surface* surface,
++    WaylandWindow* window) {
++  if (!surface) {
++    return;
++  }
++  // Only clear the entry if this window still owns it. Otherwise a panel being
++  // torn down would take focus routing away from a sibling that had since
++  // claimed it.
++  auto it = embedded_window_map_.find(surface);
++  if (it != embedded_window_map_.end() && it->second.get() == window) {
++    embedded_window_map_.erase(it);
++  }
++}
++
++std::optional<float> WaylandWindowManager::GetPreferredScaleForForeignSurface(
++    wl_surface* surface,
++    const WaylandWindow* except) const {
++  if (!surface) {
++    return std::nullopt;
++  }
++  // Siblings are usually but not necessarily on the same output: a wl_surface
++  // may span several, so a host straddling two monitors can have panels at
++  // different scales. Inherit only when every sibling agrees; otherwise there
++  // is no answer here worth preferring over the primary display.
++  std::optional<float> agreed;
++  for (const auto& entry : window_map_) {
++    WaylandWindow* window = entry.second;
++    if (window == except) {
++      continue;
++    }
++    auto* embedded = window->AsWaylandEmbeddedWindow();
++    if (!embedded || embedded->parent_surface() != surface) {
++      continue;
++    }
++    auto scale = window->GetPreferredScaleFactor();
++    if (!scale) {
++      continue;
++    }
++    if (agreed && *agreed != *scale) {
++      return std::nullopt;
++    }
++    agreed = scale;
++  }
++  return agreed;
++}
++
++void WaylandWindowManager::SetKeyboardFocusedForeignSurface(
++    wl_surface* surface) {
++  keyboard_focused_foreign_surface_ = surface;
++}
++
++void WaylandWindowManager::SetTextInputFocusedForeignSurface(
++    wl_surface* surface) {
++  text_input_focused_foreign_surface_ = surface;
++}
++
+ void WaylandWindowManager::DumpState(std::ostream& out) const {
+   int i = 0;
+   out << "WaylandWindowManager:" << std::endl;
+diff --git ui/ozone/platform/wayland/host/wayland_window_manager.h ui/ozone/platform/wayland/host/wayland_window_manager.h
+index 7735975074d667ab2b8ff13dc385bc0ec3432272..1cc81ff3563f845075f1ae65772beed8b9628ad1 100644
+--- ui/ozone/platform/wayland/host/wayland_window_manager.h
++++ ui/ozone/platform/wayland/host/wayland_window_manager.h
+@@ -130,6 +130,81 @@ class WaylandWindowManager {
+   // Creates a new unique gfx::AcceleratedWidget.
+   gfx::AcceleratedWidget AllocateAcceleratedWidget();
+ 
++  // Registers a wl_surface owned by an embedding application so that it can be
++  // named by a gfx::AcceleratedWidget and used as PlatformWindowInitProperties
++  // ::parent_widget. This lets an embedder reach the Wayland parenting code
++  // through the ordinary views plumbing, which only speaks AcceleratedWidget.
++  //
++  // The surface is not owned here and no WaylandWindow is created for it;
++  // GetWindow() keeps returning null for the returned widget. Chromium cannot
++  // query such a surface for size, scale or activation state.
++  // |xdg_surface| is the embedder's xdg_surface, needed as the parent of any
++  // xdg_popup the embedded window spawns; may be null, in which case popups
++  // cannot be created.
++  gfx::AcceleratedWidget RegisterForeignSurface(wl_surface* surface,
++                                                xdg_surface* xdg_surface);
++  void UnregisterForeignSurface(gfx::AcceleratedWidget widget);
++
++  // Returns the surface registered for |widget|, or null.
++  wl_surface* GetForeignSurface(gfx::AcceleratedWidget widget) const;
++  struct xdg_surface* GetForeignXdgSurface(gfx::AcceleratedWidget widget) const;
++
++  // The embedded window attached to |surface|, or null. Input delivered to an
++  // embedder's surface -- wl_keyboard.enter always is, because a wl_subsurface
++  // never holds keyboard focus -- belongs to the window embedded inside it.
++  //
++  // This runs for every event on a surface Chromium does not own, which
++  // includes each pointer motion over the embedder's own decorations, so it is
++  // a map lookup rather than a scan over the windows.
++  WaylandWindow* GetEmbeddedWindowForForeignSurface(wl_surface* surface) const;
++
++  // Several embedded windows can share one embedder surface -- a host with two
++  // browser panels in the same window -- but only one of them can hold keyboard
++  // focus, and the embedder decides which. Maintained by WaylandEmbeddedWindow
++  // through Activate()/Deactivate() and its own lifetime.
++  void SetEmbeddedWindowForForeignSurface(wl_surface* surface,
++                                          WaylandWindow* window);
++  void RemoveEmbeddedWindowForForeignSurface(wl_surface* surface,
++                                             WaylandWindow* window);
++
++  // The embedder surface the seat's keyboard focus is on, or null. Recorded
++  // from wl_keyboard.enter, which is the only place the protocol names it: a
++  // wl_subsurface never receives that event, so an embedded window cannot
++  // learn it from its own state.
++  //
++  // Needed because enter fires once and is not repeated while focus stays in
++  // the embedder's window. An embedded window activated after that point has
++  // to take |keyboard_focused_window_| over from its sibling, and this is how
++  // it knows the keys are addressed to its embedder at all.
++  // The scale a window already embedded in |surface| is rendering at, ignoring
++  // |except|. Used to seed a newly embedded window, which has no parent
++  // WaylandWindow to inherit from and cannot ask which output the embedding
++  // application's surface is on.
++  //
++  // A seed, not an answer: siblings sharing an embedder surface are usually but
++  // not necessarily on the same output, since a wl_surface may span several.
++  // wp_fractional_scale_v1.preferred_scale corrects it.
++  std::optional<float> GetPreferredScaleForForeignSurface(
++      wl_surface* surface,
++      const WaylandWindow* except) const;
++
++  void SetKeyboardFocusedForeignSurface(wl_surface* surface);
++  wl_surface* keyboard_focused_foreign_surface() const {
++    return keyboard_focused_foreign_surface_;
++  }
++
++  // The same for zwp_text_input_v3, which is a separate focus with a separate
++  // enter event. A keyboard enter is not evidence of a text-input one: the
++  // protocol defines enable against the surface a text-input enter named, and
++  // some compositors do not send that event at all unless an input method is
++  // running. Recorded so that a browser created after the enter can still
++  // recognise the focus as belonging to its embedder, which is otherwise lost
++  // -- the compositor does not repeat it.
++  void SetTextInputFocusedForeignSurface(wl_surface* surface);
++  wl_surface* text_input_focused_foreign_surface() const {
++    return text_input_focused_foreign_surface_;
++  }
++
+   // Returns the current value that to be used as windows' UI scale. If UI
+   // scaling feature is disabled or unavailable (eg: per-surface scaling
+   // unsupported), 1 is returned. If present, the value passed in through the
+@@ -156,6 +231,22 @@ class WaylandWindowManager {
+                  raw_ptr<WaylandWindow, CtnExperimental>>
+       window_map_;
+ 
++  // Surfaces owned by an embedding application. Deliberately separate from
++  // |window_map_|: these have no WaylandWindow behind them.
++  struct ForeignSurface {
++    raw_ptr<wl_surface, CtnExperimental> surface = nullptr;
++    raw_ptr<struct xdg_surface, CtnExperimental> xdg_surface = nullptr;
++  };
++  base::flat_map<gfx::AcceleratedWidget, ForeignSurface> foreign_surface_map_;
++
++  base::flat_map<wl_surface*, raw_ptr<WaylandWindow, CtnExperimental>>
++      embedded_window_map_;
++
++  raw_ptr<wl_surface, CtnExperimental> keyboard_focused_foreign_surface_ =
++      nullptr;
++  raw_ptr<wl_surface, CtnExperimental> text_input_focused_foreign_surface_ =
++      nullptr;
++
+   // The cache of |primary_subsurface_| of the last closed WaylandWindow. This
+   // will be destroyed lazily to make sure the window closing animation works
+   // well. See crbug.com/1324548.
+diff --git ui/ozone/platform/wayland/host/xdg_popup.cc ui/ozone/platform/wayland/host/xdg_popup.cc
+index 94987c9695e51058698060f25947bdb6dcd80e6d..72813f3cf40a5ccb98d6cd79dd2102cd1af69fe1 100644
+--- ui/ozone/platform/wayland/host/xdg_popup.cc
++++ ui/ozone/platform/wayland/host/xdg_popup.cc
+@@ -17,6 +17,7 @@
+ #include "ui/gfx/geometry/rect.h"
+ #include "ui/ozone/platform/wayland/common/wayland_util.h"
+ #include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_embedded_window.h"
+ #include "ui/ozone/platform/wayland/host/wayland_popup.h"
+ #include "ui/ozone/platform/wayland/host/wayland_seat.h"
+ #include "ui/ozone/platform/wayland/host/wayland_serial_tracker.h"
+@@ -140,6 +141,23 @@ bool XdgPopup::Initialize(const InitParams& params) {
+     parent_xdg_surface = parent_popup->xdg_popup()->xdg_surface();
+   } else if (auto* parent_toplevel = xdg_parent->AsWaylandToplevelWindow()) {
+     parent_xdg_surface = parent_toplevel->xdg_toplevel()->xdg_surface();
++  } else if (auto* parent_embedded = xdg_parent->AsWaylandEmbeddedWindow()) {
++    // An embedded window has no xdg_surface, so its popups hang off the
++    // embedding application's. There is no protocol that lets a popup anchor to
++    // a wl_subsurface: xdg_surface.get_popup takes an xdg_surface, and the only
++    // way to name a foreign one, xdg_foreign, rejects anything that is not "an
++    // xdg_toplevel equivalent". Borrowing the embedder's is what is left.
++    parent_xdg_surface = parent_embedded->foreign_xdg_surface();
++    if (!parent_xdg_surface) {
++      // Unlike the cases above, this one depends on what an embedding
++      // application passed in, so it is a runtime failure rather than a broken
++      // invariant. Returning false leaves the browser usable without popups;
++      // falling through to the CHECK below would abort the host process the
++      // first time the user opened a <select>.
++      LOG(ERROR) << "The embedding application provided no xdg_surface; menus, "
++                    "tooltips and <select> dropdowns cannot be opened";
++      return false;
++    }
+   }
+ 
+   CHECK(xdg_surface_ && parent_xdg_surface);
+diff --git ui/ozone/platform/wayland/host/zwp_text_input_v3.cc ui/ozone/platform/wayland/host/zwp_text_input_v3.cc
+index c39d9cf5a0076da324f30881688215312aac00de..592da3ec0852f00887fcbb373aea6b0283f94170 100644
+--- ui/ozone/platform/wayland/host/zwp_text_input_v3.cc
++++ ui/ozone/platform/wayland/host/zwp_text_input_v3.cc
+@@ -18,6 +18,8 @@
+ #include "ui/ozone/platform/wayland/host/wayland_connection.h"
+ #include "ui/ozone/platform/wayland/host/wayland_seat.h"
+ #include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_window_manager.h"
++#include "ui/ozone/platform/wayland/wayland_embedder.h"
+ 
+ namespace ui {
+ 
+@@ -363,7 +365,18 @@ void ZwpTextInputV3Impl::OnEnter(void* data,
+                                  struct zwp_text_input_v3* text_input,
+                                  struct wl_surface* surface) {
+   auto* self = static_cast<ZwpTextInputV3Impl*>(data);
+-  if (auto* window = wl::RootWindowFromWlSurface(surface)) {
++
++  // Record the surface itself, as WaylandKeyboard::OnEnter does. When it
++  // belongs to an embedding application this is the only event that names it,
++  // and it is not repeated: a browser created afterwards would otherwise have
++  // no way to know the input method is pointed at its embedder, and on a seat
++  // with no keyboard there is no other signal to fall back on.
++  if (surface && !ui::ChromiumSurfaceFor(surface)) {
++    self->connection_->window_manager()->SetTextInputFocusedForeignSurface(
++        surface);
++  }
++
++  if (auto* window = wl::KeyboardWindowFromWlSurface(surface)) {
+     self->connection_->window_manager()->SetTextInputFocusedWindow(window);
+   }
+ }
+@@ -372,7 +385,11 @@ void ZwpTextInputV3Impl::OnLeave(void* data,
+                                  struct zwp_text_input_v3* text_input,
+                                  struct wl_surface* surface) {
+   auto* self = static_cast<ZwpTextInputV3Impl*>(data);
+-  self->connection_->window_manager()->SetTextInputFocusedWindow(nullptr);
++  auto* manager = self->connection_->window_manager();
++  if (surface && manager->text_input_focused_foreign_surface() == surface) {
++    manager->SetTextInputFocusedForeignSurface(nullptr);
++  }
++  manager->SetTextInputFocusedWindow(nullptr);
+ }
+ 
+ void ZwpTextInputV3Impl::OnPreeditString(void* data,
+diff --git ui/ozone/platform/wayland/wayland_embedder.cc ui/ozone/platform/wayland/wayland_embedder.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..9353482eedd1c4c5cfd867c14abeb6ee82618ab5
+--- /dev/null
++++ ui/ozone/platform/wayland/wayland_embedder.cc
+@@ -0,0 +1,122 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "ui/ozone/platform/wayland/wayland_embedder.h"
++
++#include <atomic>
++
++#include "base/containers/flat_map.h"
++#include "base/no_destructor.h"
++#include "base/sequence_checker.h"
++#include "ui/ozone/platform/wayland/host/wayland_connection.h"
++#include "ui/ozone/platform/wayland/host/wayland_surface.h"
++#include "ui/ozone/platform/wayland/host/wayland_window.h"
++#include "ui/ozone/platform/wayland/host/wayland_window_manager.h"
++
++namespace ui {
++
++namespace {
++
++// Written on the embedder's own thread before CefInitialize() and read later on
++// whichever thread Ozone starts on. Those are the same thread only when the
++// host drives the message loop itself; with a multi-threaded message loop the
++// browser UI thread is a different one, which is why this is not guarded by the
++// sequence checker below and is not a plain pointer.
++std::atomic<wl_display*> g_external_display{nullptr};
++
++WaylandConnection* g_connection = nullptr;
++wl_display* g_display = nullptr;
++
++// Guards the two globals above and the maps below, which carry no locking of
++// their own. Everything it guards is reached only from the thread Ozone runs
++// on, so the checker binds on first use rather than at construction.
++SEQUENCE_CHECKER(g_sequence_checker);
++
++base::flat_map<wl_surface*, WaylandSurface*>& ChromiumSurfaces() {
++  static base::NoDestructor<base::flat_map<wl_surface*, WaylandSurface*>> map;
++  return *map;
++}
++
++}  // namespace
++
++void SetExternalWaylandDisplay(wl_display* display) {
++  g_external_display.store(display, std::memory_order_release);
++}
++
++wl_display* GetExternalWaylandDisplay() {
++  return g_external_display.load(std::memory_order_acquire);
++}
++
++gfx::AcceleratedWidget RegisterForeignWaylandSurface(wl_surface* surface,
++                                                     xdg_surface* xdg_surface) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(g_sequence_checker);
++  if (!g_connection || !surface) {
++    return gfx::kNullAcceleratedWidget;
++  }
++  return g_connection->window_manager()->RegisterForeignSurface(surface,
++                                                                xdg_surface);
++}
++
++void UnregisterForeignWaylandSurface(gfx::AcceleratedWidget widget) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(g_sequence_checker);
++  if (g_connection) {
++    g_connection->window_manager()->UnregisterForeignSurface(widget);
++  }
++}
++
++wl_surface* GetWaylandSurfaceForWidget(gfx::AcceleratedWidget widget) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(g_sequence_checker);
++  if (!g_connection) {
++    return nullptr;
++  }
++  WaylandWindow* window = g_connection->window_manager()->GetWindow(widget);
++  if (!window || !window->root_surface()) {
++    return nullptr;
++  }
++  return window->root_surface()->surface();
++}
++
++void RegisterChromiumSurface(wl_surface* surface, WaylandSurface* owner) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(g_sequence_checker);
++  if (surface) {
++    ChromiumSurfaces()[surface] = owner;
++  }
++}
++
++void UnregisterChromiumSurface(wl_surface* surface) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(g_sequence_checker);
++  if (surface) {
++    ChromiumSurfaces().erase(surface);
++  }
++}
++
++WaylandSurface* ChromiumSurfaceFor(wl_surface* surface) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(g_sequence_checker);
++  auto& map = ChromiumSurfaces();
++  auto it = map.find(surface);
++  return it == map.end() ? nullptr : it->second;
++}
++
++WaylandWindow* EmbeddedWindowForForeignSurface(wl_surface* surface) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(g_sequence_checker);
++  if (!g_connection) {
++    return nullptr;
++  }
++  return g_connection->window_manager()->GetEmbeddedWindowForForeignSurface(
++      surface);
++}
++
++void SetWaylandConnectionForEmbedders(WaylandConnection* connection,
++                                      wl_display* display) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(g_sequence_checker);
++  g_connection = connection;
++  g_display = display;
++}
++
++wl_display* GetWaylandDisplay() {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(g_sequence_checker);
++  return g_display;
++}
++
++}  // namespace ui
+diff --git ui/ozone/platform/wayland/wayland_embedder.h ui/ozone/platform/wayland/wayland_embedder.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..90954ea981932fdb3489e8b0c683c6bf4c50ea3b
+--- /dev/null
++++ ui/ozone/platform/wayland/wayland_embedder.h
+@@ -0,0 +1,106 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef UI_OZONE_PLATFORM_WAYLAND_WAYLAND_EMBEDDER_H_
++#define UI_OZONE_PLATFORM_WAYLAND_WAYLAND_EMBEDDER_H_
++
++#include "base/component_export.h"
++#include "ui/gfx/native_ui_types.h"
++
++struct wl_display;
++struct wl_surface;
++struct xdg_surface;
++
++namespace ui {
++
++class WaylandConnection;
++class WaylandSurface;
++class WaylandWindow;
++
++// Everything in this file is confined to the UI thread, which is where Ozone
++// creates and destroys its Wayland objects and where the embedder's calls
++// arrive. The state behind it is plain globals with no locking, so calling any
++// of it from another thread is a data race; the implementation DCHECKs.
++//
++// SetExternalWaylandDisplay() and GetExternalWaylandDisplay() are the two
++// exceptions, and have to be: the display is handed over before Ozone starts,
++// on whatever thread the embedder called CefInitialize() from, and read back
++// later on the UI thread. Those are different threads whenever the host runs a
++// multi-threaded message loop, so that one value is atomic and unchecked.
++
++// Entry points for an application that wants to host Chromium web content
++// inside a window it owns, rather than letting Chromium create its own
++// toplevel. See WaylandEmbeddedWindow.
++
++// Hands Ozone a wl_display owned by the embedding application, so that
++// WaylandConnection joins it instead of calling wl_display_connect(). A
++// wl_surface is a protocol object scoped to its connection and
++// wl_subcompositor_get_subsurface() rejects surfaces from a different one, so
++// there is no way to parent a Chromium surface to the embedder's surface
++// without sharing the connection.
++//
++// Must be called before OzonePlatform::InitializeUI(); the connection is made
++// during Ozone startup. Ownership stays with the caller, which must keep the
++// display alive for as long as Ozone is running. Ignored when the selected
++// Ozone platform is not Wayland.
++COMPONENT_EXPORT(OZONE) void SetExternalWaylandDisplay(wl_display* display);
++COMPONENT_EXPORT(OZONE) wl_display* GetExternalWaylandDisplay();
++
++// The connection Chromium is actually using, whether it opened one or adopted
++// the embedder's. Null before Ozone starts or when the platform is not Wayland.
++COMPONENT_EXPORT(OZONE) wl_display* GetWaylandDisplay();
++
++// Names a wl_surface owned by the embedding application with a
++// gfx::AcceleratedWidget, so that it can be passed as
++// views::Widget::InitParams::parent_widget. Creating a window with that parent
++// produces a WaylandEmbeddedWindow attached to |surface| as a wl_subsurface.
++//
++// views has no vocabulary for a native parent other than AcceleratedWidget, and
++// DesktopWindowTreeHostLinux already forwards it into
++// PlatformWindowInitProperties, so naming the surface this way avoids touching
++// views at all.
++//
++// |surface| must belong to the display passed to SetExternalWaylandDisplay().
++// Returns gfx::kNullAcceleratedWidget if Wayland is not the active platform or
++// Ozone has not started yet. Release with UnregisterForeignWaylandSurface()
++// once the embedded window is gone.
++COMPONENT_EXPORT(OZONE)
++gfx::AcceleratedWidget RegisterForeignWaylandSurface(wl_surface* surface,
++                                                     xdg_surface* xdg_surface);
++COMPONENT_EXPORT(OZONE)
++void UnregisterForeignWaylandSurface(gfx::AcceleratedWidget widget);
++
++// Returns the wl_surface backing |widget|, or null if there is no Wayland
++// window for it. Lets an embedder learn the surface Chromium created for an
++// embedded window, which is otherwise not observable from outside Ozone.
++COMPONENT_EXPORT(OZONE)
++wl_surface* GetWaylandSurfaceForWidget(gfx::AcceleratedWidget widget);
++
++// Chromium's own wl_surface objects, tracked so that a wl_surface arriving from
++// the compositor can be resolved without reading its user data.
++//
++// When Chromium shares a connection with an embedding application, that
++// application's surfaces travel over the same connection and are handed back in
++// events like wl_pointer.enter. Their user data belongs to the embedder's
++// toolkit -- a winit client, for instance, has one per client-side decoration
++// -- so casting it to WaylandSurface is undefined. Registering our own is the
++// only way to tell them apart; there is no protocol-level ownership query.
++COMPONENT_EXPORT(OZONE)
++void RegisterChromiumSurface(wl_surface* surface, WaylandSurface* owner);
++COMPONENT_EXPORT(OZONE) void UnregisterChromiumSurface(wl_surface* surface);
++COMPONENT_EXPORT(OZONE)
++WaylandSurface* ChromiumSurfaceFor(wl_surface* surface);
++
++// The window embedded inside |surface|, or null.
++COMPONENT_EXPORT(OZONE)
++WaylandWindow* EmbeddedWindowForForeignSurface(wl_surface* surface);
++
++// Internal. WaylandConnection publishes itself here so that the functions above
++// can reach the window manager without exposing the platform's internals.
++void SetWaylandConnectionForEmbedders(WaylandConnection* connection,
++                                      wl_display* display);
++
++}  // namespace ui
++
++#endif  // UI_OZONE_PLATFORM_WAYLAND_WAYLAND_EMBEDDER_H_

--- a/tests/cefembed_wayland/main.cc
+++ b/tests/cefembed_wayland/main.cc
@@ -1,0 +1,869 @@
+// Copyright 2026 The Chromium Embedded Framework Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// Minimal Wayland client that embeds a CEF browser inside its own window, the
+// way OBS embeds a browser dock or Steam embeds its store view.
+//
+// cefclient's Linux windowing path is GTK over X11 and hands CEF an XID
+// (GDK_WINDOW_XID in root_window_gtk.cc, temp_window_x11.cc), so there is no
+// wl_surface to pass through it. This exists to exercise the three-argument
+// CefWindowInfo::SetAsChild() end to end:
+//
+//   * open a wl_display and hand it to CEF before CefInitialize;
+//   * create an xdg_toplevel and paint a plain host UI into it with wl_shm;
+//   * create a browser as a wl_subsurface of that surface;
+//   * drive both event loops from one thread.
+//
+// The layout mirrors the host applications this is meant to serve: a sidebar
+// the client owns, and a content rectangle handed to the browser. If embedding
+// fails, that rectangle stays the colour the client painted, which makes the
+// failure visible rather than silent.
+
+#include <poll.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wayland-client.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "cursor-shape-v1-client-protocol.h"
+#include "include/cef_app.h"
+#include "include/cef_browser.h"
+#include "include/cef_client.h"
+#include "include/wrapper/cef_helpers.h"
+#include "xdg-shell-client-protocol.h"
+
+namespace {
+
+constexpr int kWidth = 1280;
+constexpr int kHeight = 800;
+constexpr int kSidebarWidth = 200;
+constexpr int kHeaderHeight = 48;
+// GNOME does not advertise zxdg_decoration_manager_v1, so there is no way to
+// ask for server-side decorations: the client has to draw its own and drive
+// moving and resizing itself. This is the grab area along the window edges.
+constexpr int kResizeBorder = 12;
+constexpr int kCloseButtonSize = 40;
+
+// Smallest window this program will paint: enough for the sidebar, the close
+// button and a content rectangle that is not empty.
+constexpr int kMinWidth = kSidebarWidth + kCloseButtonSize + 2 * kResizeBorder;
+constexpr int kMinHeight = kHeaderHeight + 2 * kResizeBorder;
+
+// Colours are XRGB8888, matching wl_shm's default format.
+constexpr uint32_t kSidebarColor = 0xff171a21;
+constexpr uint32_t kHeaderColor = 0xff101822;
+// Deliberately loud: if the browser subsurface never appears, this is what the
+// user sees where the page should be.
+constexpr uint32_t kVoidColor = 0xff240d0d;
+constexpr uint32_t kCloseColor = 0xffc94d3f;
+constexpr uint32_t kBorderColor = 0xff2a475e;
+
+// One wl_shm buffer and the mapping behind it. |busy| is true from the moment
+// the buffer is attached until the compositor releases it; until then neither
+// the wl_buffer nor its storage may be touched.
+struct Buffer {
+  wl_buffer* buffer = nullptr;
+  uint32_t* pixels = nullptr;
+  size_t size = 0;
+  int width = 0;
+  int height = 0;
+  bool busy = false;
+};
+
+struct Host {
+  wl_display* display = nullptr;
+  wl_registry* registry = nullptr;
+  wl_compositor* compositor = nullptr;
+  wl_shm* shm = nullptr;
+  xdg_wm_base* wm_base = nullptr;
+  wl_seat* seat = nullptr;
+  wl_pointer* pointer = nullptr;
+  wp_cursor_shape_manager_v1* cursor_shape_manager = nullptr;
+  wp_cursor_shape_device_v1* cursor_shape_device = nullptr;
+  uint32_t last_enter_serial = 0;
+  uint32_t current_cursor = 0;
+
+  // Latest pointer position over our own surface, and the serial of the last
+  // button press. xdg_toplevel.move and .resize both need a serial.
+  double pointer_x = 0;
+  double pointer_y = 0;
+  bool pointer_on_host_surface = false;
+
+  wl_surface* surface = nullptr;
+  xdg_surface* xdg_surface_obj = nullptr;
+  xdg_toplevel* toplevel = nullptr;
+
+  int width = kWidth;
+  int height = kHeight;
+  bool configured = false;
+  bool closed = false;
+
+  // Every buffer this program has allocated. A wl_buffer may not be destroyed
+  // or its storage reused until the compositor sends wl_buffer.release; it may
+  // still be reading from it to paint the current frame. A resize drag produces
+  // a configure per frame, so this is the difference between a correct client
+  // and one that shows torn or undefined content while being resized.
+  std::vector<std::unique_ptr<Buffer>> buffers;
+
+  // Lives here rather than at namespace scope so that its destructor runs when
+  // main() returns instead of at exit time.
+  CefRefPtr<CefBrowser> browser;
+};
+
+Host* g_host = nullptr;
+
+// --- wl_shm buffer -----------------------------------------------------------
+
+void OnBufferRelease(void* data, wl_buffer* /*buffer*/) {
+  static_cast<Buffer*>(data)->busy = false;
+}
+
+const wl_buffer_listener kBufferListener = {
+    .release = &OnBufferRelease,
+};
+
+void DestroyBuffer(Buffer* buffer) {
+  if (buffer->buffer) {
+    wl_buffer_destroy(buffer->buffer);
+  }
+  if (buffer->pixels) {
+    munmap(buffer->pixels, buffer->size);
+  }
+}
+
+// Returns a buffer of the current window size that the compositor is not
+// reading from. Reuses one when possible; a resize allocates a new one and
+// drops any idle buffer of the old size.
+Buffer* AcquireBuffer(Host* host) {
+  const int width = host->width;
+  const int height = host->height;
+
+  // Reap what the compositor has handed back, keeping idle buffers that still
+  // match the current size.
+  std::erase_if(host->buffers, [&](const std::unique_ptr<Buffer>& buffer) {
+    if (buffer->busy || (buffer->width == width && buffer->height == height)) {
+      return false;
+    }
+    DestroyBuffer(buffer.get());
+    return true;
+  });
+
+  for (const auto& buffer : host->buffers) {
+    if (!buffer->busy && buffer->width == width && buffer->height == height) {
+      return buffer.get();
+    }
+  }
+
+  const int stride = width * 4;
+  const int size = stride * height;
+
+  char name[] = "/cefembed-XXXXXX";
+  const int fd = memfd_create(name, MFD_CLOEXEC);
+  if (fd < 0 || ftruncate(fd, size) < 0) {
+    fprintf(stderr, "cefembed: failed to allocate a shm buffer\n");
+    if (fd >= 0) {
+      close(fd);
+    }
+    return nullptr;
+  }
+
+  auto* pixels = static_cast<uint32_t*>(
+      mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+  if (pixels == MAP_FAILED) {
+    close(fd);
+    return nullptr;
+  }
+
+  wl_shm_pool* pool = wl_shm_create_pool(host->shm, fd, size);
+  wl_buffer* wl_buffer_obj = wl_shm_pool_create_buffer(
+      pool, 0, width, height, stride, WL_SHM_FORMAT_XRGB8888);
+  wl_shm_pool_destroy(pool);
+  close(fd);
+
+  if (!wl_buffer_obj) {
+    munmap(pixels, size);
+    fprintf(stderr, "cefembed: wl_shm_pool_create_buffer failed\n");
+    return nullptr;
+  }
+
+  auto buffer = std::make_unique<Buffer>();
+  buffer->buffer = wl_buffer_obj;
+  buffer->pixels = pixels;
+  buffer->size = static_cast<size_t>(size);
+  buffer->width = width;
+  buffer->height = height;
+  wl_buffer_add_listener(wl_buffer_obj, &kBufferListener, buffer.get());
+
+  host->buffers.push_back(std::move(buffer));
+  return host->buffers.back().get();
+}
+
+// Clipped to the buffer on both edges. The callers below derive rectangles from
+// the window size, and a compositor is free to configure a window smaller than
+// any minimum this program has in mind, at which point an unclipped fill writes
+// past the end of the mapping.
+void FillRect(uint32_t* pixels,
+              int pitch,
+              int rows,
+              int x,
+              int y,
+              int w,
+              int h,
+              uint32_t color) {
+  const int x0 = std::max(x, 0);
+  const int y0 = std::max(y, 0);
+  const int x1 = std::min(x + w, pitch);
+  const int y1 = std::min(y + h, rows);
+  for (int row = y0; row < y1; ++row) {
+    for (int col = x0; col < x1; ++col) {
+      pixels[row * pitch + col] = color;
+    }
+  }
+}
+
+// Paints the part of the window the client owns. The content rectangle is left
+// in kVoidColor so that a missing browser surface is obvious.
+void PaintHostChrome(Host* host) {
+  // Once closing has started, any repaint would attach a buffer and remap the
+  // window that the shutdown path just took off screen -- reappearing without
+  // the browser inside it, since the subsurface is gone by then.
+  if (host->closed) {
+    return;
+  }
+
+  Buffer* buffer = AcquireBuffer(host);
+  if (!buffer) {
+    return;
+  }
+  uint32_t* pixels = buffer->pixels;
+  const int w = host->width;
+  const int h = host->height;
+
+  FillRect(pixels, w, h, 0, 0, w, h, kVoidColor);
+  FillRect(pixels, w, h, 0, 0, w, kHeaderHeight, kHeaderColor);
+  FillRect(pixels, w, h, 0, kHeaderHeight, kSidebarWidth, h - kHeaderHeight,
+           kSidebarColor);
+
+  // Client-side decoration, such as it is: a resize border and a close button.
+  FillRect(pixels, w, h, 0, 0, w, kResizeBorder, kBorderColor);
+  FillRect(pixels, w, h, 0, h - kResizeBorder, w, kResizeBorder, kBorderColor);
+  FillRect(pixels, w, h, 0, 0, kResizeBorder, h, kBorderColor);
+  FillRect(pixels, w, h, w - kResizeBorder, 0, kResizeBorder, h, kBorderColor);
+  FillRect(pixels, w, h, w - kCloseButtonSize - kResizeBorder, kResizeBorder,
+           kCloseButtonSize, kCloseButtonSize - kResizeBorder, kCloseColor);
+
+  buffer->busy = true;
+  wl_surface_attach(host->surface, buffer->buffer, 0, 0);
+  wl_surface_damage_buffer(host->surface, 0, 0, host->width, host->height);
+  // This commit also publishes any pending wl_subsurface state for the
+  // embedded browser, which is why the host has to repaint after moving it.
+  wl_surface_commit(host->surface);
+}
+
+CefRect ContentBounds(const Host* host) {
+  return CefRect(kSidebarWidth, kHeaderHeight, host->width - kSidebarWidth,
+                 host->height - kHeaderHeight);
+}
+
+// --- Wayland listeners -------------------------------------------------------
+
+void OnXdgSurfaceConfigure(void* data, xdg_surface* surface, uint32_t serial) {
+  auto* host = static_cast<Host*>(data);
+  xdg_surface_ack_configure(surface, serial);
+  host->configured = true;
+  PaintHostChrome(host);
+}
+
+const xdg_surface_listener kXdgSurfaceListener = {
+    .configure = OnXdgSurfaceConfigure,
+};
+
+void OnToplevelConfigure(void* data,
+                         xdg_toplevel*,
+                         int32_t width,
+                         int32_t height,
+                         wl_array*) {
+  auto* host = static_cast<Host*>(data);
+  if (width > 0 && height > 0) {
+    // A compositor may configure any size it likes, including one narrower
+    // than the sidebar or shorter than the header. The chrome this program
+    // paints has no layout to speak of, so refuse to go below the point where
+    // the content rectangle would be empty rather than paint nonsense.
+    host->width = std::max(width, kMinWidth);
+    host->height = std::max(height, kMinHeight);
+    if (host->browser) {
+      // The embedded browser does not observe the host's configure events; the
+      // host has to push the new geometry down. This is the contract change
+      // that Wayland embedding forces on every embedder.
+      host->browser->GetHost()->SetWindowBounds(ContentBounds(host));
+    }
+  }
+}
+
+void OnToplevelClose(void* data, xdg_toplevel*) {
+  printf("cefembed: compositor asked the window to close\n");
+  fflush(stdout);
+  static_cast<Host*>(data)->closed = true;
+}
+
+const xdg_toplevel_listener kToplevelListener = {
+    .configure = OnToplevelConfigure,
+    .close = OnToplevelClose,
+};
+
+// Which resize edge, if any, the pointer is over. Returns 0 for "not on an
+// edge", which xdg_toplevel_resize would reject anyway.
+uint32_t ResizeEdgeAt(const Host* host, double x, double y) {
+  const bool left = x < kResizeBorder;
+  const bool right = x >= host->width - kResizeBorder;
+  const bool top = y < kResizeBorder;
+  const bool bottom = y >= host->height - kResizeBorder;
+
+  if (top && left) {
+    return XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
+  }
+  if (top && right) {
+    return XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
+  }
+  if (bottom && left) {
+    return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
+  }
+  if (bottom && right) {
+    return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
+  }
+  if (top) {
+    return XDG_TOPLEVEL_RESIZE_EDGE_TOP;
+  }
+  if (bottom) {
+    return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
+  }
+  if (left) {
+    return XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
+  }
+  if (right) {
+    return XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
+  }
+  return XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+}
+
+bool IsOverCloseButton(const Host* host, double x, double y) {
+  return x >= host->width - kCloseButtonSize - kResizeBorder &&
+         x < host->width - kResizeBorder && y >= kResizeBorder &&
+         y < kCloseButtonSize;
+}
+
+// Maps a resize edge to the cursor that advertises it. A Wayland client gets no
+// cursor at all unless it sets one, so without this the border looks inert even
+// though it works.
+uint32_t CursorShapeForEdge(uint32_t edge) {
+  switch (edge) {
+    case XDG_TOPLEVEL_RESIZE_EDGE_TOP:
+      return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_N_RESIZE;
+    case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:
+      return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_S_RESIZE;
+    case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:
+      return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_W_RESIZE;
+    case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:
+      return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_E_RESIZE;
+    case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:
+      return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NW_RESIZE;
+    case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:
+      return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NE_RESIZE;
+    case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:
+      return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_SW_RESIZE;
+    case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT:
+      return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_SE_RESIZE;
+    default:
+      return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT;
+  }
+}
+
+void UpdateCursor(Host* host);
+
+void OnPointerEnter(void* data,
+                    wl_pointer*,
+                    uint32_t serial,
+                    wl_surface* surface,
+                    wl_fixed_t x,
+                    wl_fixed_t y) {
+  auto* host = static_cast<Host*>(data);
+  // Only our own surface; the browser's subsurface is Chromium's business and
+  // it receives its own pointer events directly.
+  host->pointer_on_host_surface = (surface == host->surface);
+  host->pointer_x = wl_fixed_to_double(x);
+  host->pointer_y = wl_fixed_to_double(y);
+  host->last_enter_serial = serial;
+  UpdateCursor(host);
+}
+
+void OnPointerLeave(void* data, wl_pointer*, uint32_t, wl_surface*) {
+  auto* host = static_cast<Host*>(data);
+  host->pointer_on_host_surface = false;
+}
+
+void OnPointerMotion(void* data,
+                     wl_pointer*,
+                     uint32_t,
+                     wl_fixed_t x,
+                     wl_fixed_t y) {
+  auto* host = static_cast<Host*>(data);
+  host->pointer_x = wl_fixed_to_double(x);
+  host->pointer_y = wl_fixed_to_double(y);
+  UpdateCursor(host);
+}
+
+void OnPointerButton(void* data,
+                     wl_pointer*,
+                     uint32_t serial,
+                     uint32_t,
+                     uint32_t button,
+                     uint32_t state) {
+  auto* host = static_cast<Host*>(data);
+
+  constexpr uint32_t kLeftButton = 0x110;  // BTN_LEFT
+  if (button != kLeftButton || state != WL_POINTER_BUTTON_STATE_PRESSED ||
+      !host->pointer_on_host_surface || host->closed) {
+    return;
+  }
+
+  if (IsOverCloseButton(host, host->pointer_x, host->pointer_y)) {
+    printf("cefembed: close button clicked\n");
+    fflush(stdout);
+    host->closed = true;
+    return;
+  }
+
+  const uint32_t edge = ResizeEdgeAt(host, host->pointer_x, host->pointer_y);
+  if (edge != XDG_TOPLEVEL_RESIZE_EDGE_NONE) {
+    xdg_toplevel_resize(host->toplevel, host->seat, serial, edge);
+    return;
+  }
+
+  // Anywhere else in the chrome we own drags the window. The browser's
+  // subsurface never delivers pointer events here, so a press we can see is a
+  // press on our own UI.
+  if (host->pointer_y < kHeaderHeight) {
+    xdg_toplevel_move(host->toplevel, host->seat, serial);
+  }
+}
+
+// Every member must be filled in: libwayland aborts the process with
+// "listener function for opcode N of wl_pointer is NULL" the first time the
+// compositor sends an event whose slot is null. wl_seat version 5 already
+// implies frame/axis_source/axis_stop/axis_discrete, and later versions add
+// more, so the unused ones get no-ops rather than being left out.
+void OnPointerAxis(void*, wl_pointer*, uint32_t, uint32_t, wl_fixed_t) {}
+void OnPointerFrame(void*, wl_pointer*) {}
+void OnPointerAxisSource(void*, wl_pointer*, uint32_t) {}
+void OnPointerAxisStop(void*, wl_pointer*, uint32_t, uint32_t) {}
+void OnPointerAxisDiscrete(void*, wl_pointer*, uint32_t, int32_t) {}
+void OnPointerAxisValue120(void*, wl_pointer*, uint32_t, int32_t) {}
+void OnPointerAxisRelativeDirection(void*, wl_pointer*, uint32_t, uint32_t) {}
+
+void UpdateCursor(Host* host) {
+  if (!host->cursor_shape_device || !host->pointer_on_host_surface) {
+    return;
+  }
+
+  uint32_t shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT;
+  const uint32_t edge = ResizeEdgeAt(host, host->pointer_x, host->pointer_y);
+  if (edge != XDG_TOPLEVEL_RESIZE_EDGE_NONE) {
+    shape = CursorShapeForEdge(edge);
+  } else if (IsOverCloseButton(host, host->pointer_x, host->pointer_y)) {
+    shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_POINTER;
+  } else if (host->pointer_y < kHeaderHeight) {
+    shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_MOVE;
+  }
+
+  if (shape == host->current_cursor) {
+    return;
+  }
+  host->current_cursor = shape;
+  wp_cursor_shape_device_v1_set_shape(host->cursor_shape_device,
+                                      host->last_enter_serial, shape);
+}
+
+const wl_pointer_listener kPointerListener = {
+    .enter = OnPointerEnter,
+    .leave = OnPointerLeave,
+    .motion = OnPointerMotion,
+    .button = OnPointerButton,
+    .axis = OnPointerAxis,
+    .frame = OnPointerFrame,
+    .axis_source = OnPointerAxisSource,
+    .axis_stop = OnPointerAxisStop,
+    .axis_discrete = OnPointerAxisDiscrete,
+    .axis_value120 = OnPointerAxisValue120,
+    .axis_relative_direction = OnPointerAxisRelativeDirection,
+};
+
+void OnSeatCapabilities(void* data, wl_seat* seat, uint32_t caps) {
+  auto* host = static_cast<Host*>(data);
+  if ((caps & WL_SEAT_CAPABILITY_POINTER) && !host->pointer) {
+    host->pointer = wl_seat_get_pointer(seat);
+    wl_pointer_add_listener(host->pointer, &kPointerListener, host);
+    if (host->cursor_shape_manager) {
+      host->cursor_shape_device = wp_cursor_shape_manager_v1_get_pointer(
+          host->cursor_shape_manager, host->pointer);
+    }
+  } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && host->pointer) {
+    // capabilities is sent again whenever the set changes, including when the
+    // last mouse is unplugged. Keeping a released pointer would leave stale
+    // objects behind and a cursor device pointing at nothing.
+    if (host->cursor_shape_device) {
+      wp_cursor_shape_device_v1_destroy(host->cursor_shape_device);
+      host->cursor_shape_device = nullptr;
+    }
+    wl_pointer_release(host->pointer);
+    host->pointer = nullptr;
+    host->pointer_on_host_surface = false;
+  }
+}
+
+void OnSeatName(void*, wl_seat*, const char*) {}
+
+const wl_seat_listener kSeatListener = {
+    .capabilities = OnSeatCapabilities,
+    .name = OnSeatName,
+};
+
+void OnWmBasePing(void*, xdg_wm_base* wm_base, uint32_t serial) {
+  xdg_wm_base_pong(wm_base, serial);
+}
+
+const xdg_wm_base_listener kWmBaseListener = {.ping = OnWmBasePing};
+
+void OnGlobal(void* data,
+              wl_registry* registry,
+              uint32_t name,
+              const char* interface,
+              uint32_t version) {
+  auto* host = static_cast<Host*>(data);
+  const std::string iface(interface);
+  if (iface == wl_compositor_interface.name) {
+    host->compositor = static_cast<wl_compositor*>(
+        wl_registry_bind(registry, name, &wl_compositor_interface, 4));
+  } else if (iface == wl_shm_interface.name) {
+    host->shm = static_cast<wl_shm*>(
+        wl_registry_bind(registry, name, &wl_shm_interface, 1));
+  } else if (iface == wp_cursor_shape_manager_v1_interface.name) {
+    host->cursor_shape_manager =
+        static_cast<wp_cursor_shape_manager_v1*>(wl_registry_bind(
+            registry, name, &wp_cursor_shape_manager_v1_interface, 1));
+  } else if (iface == wl_seat_interface.name) {
+    host->seat = static_cast<wl_seat*>(
+        wl_registry_bind(registry, name, &wl_seat_interface, 5));
+    wl_seat_add_listener(host->seat, &kSeatListener, host);
+  } else if (iface == xdg_wm_base_interface.name) {
+    host->wm_base = static_cast<xdg_wm_base*>(
+        wl_registry_bind(registry, name, &xdg_wm_base_interface, 1));
+    xdg_wm_base_add_listener(host->wm_base, &kWmBaseListener, host);
+  }
+}
+
+void OnGlobalRemove(void*, wl_registry*, uint32_t) {}
+
+const wl_registry_listener kRegistryListener = {
+    .global = OnGlobal,
+    .global_remove = OnGlobalRemove,
+};
+
+// --- CEF client --------------------------------------------------------------
+
+class EmbedClient : public CefClient, public CefLifeSpanHandler {
+ public:
+  // DISALLOW_COPY_AND_ASSIGN declares a constructor, which suppresses the
+  // implicit default one.
+  EmbedClient() = default;
+
+  CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
+
+  void OnAfterCreated(CefRefPtr<CefBrowser> browser) override {
+    CEF_REQUIRE_UI_THREAD();
+    g_host->browser = browser;
+    printf("cefembed: browser created\n");
+
+    // wl_subsurface.set_position is part of *our* surface's double-buffered
+    // state, so the browser's placement does not take effect until we commit.
+    // Nothing else would prompt us to, since the host UI has not changed.
+    if (g_host && g_host->surface) {
+      wl_surface_commit(g_host->surface);
+      wl_display_flush(g_host->display);
+    }
+  }
+
+  void OnBeforeClose(CefRefPtr<CefBrowser>) override {
+    CEF_REQUIRE_UI_THREAD();
+    g_host->browser = nullptr;
+  }
+
+ private:
+  IMPLEMENT_REFCOUNTING(EmbedClient);
+  DISALLOW_COPY_AND_ASSIGN(EmbedClient);
+};
+
+bool CreateHostWindow(Host* host) {
+  host->display = wl_display_connect(nullptr);
+  if (!host->display) {
+    fprintf(stderr,
+            "cefembed: no Wayland compositor (is WAYLAND_DISPLAY set?)\n");
+    return false;
+  }
+
+  host->registry = wl_display_get_registry(host->display);
+  wl_registry_add_listener(host->registry, &kRegistryListener, host);
+  wl_display_roundtrip(host->display);
+
+  if (!host->compositor || !host->shm || !host->wm_base || !host->seat) {
+    fprintf(stderr,
+            "cefembed: compositor is missing wl_compositor, wl_shm, "
+            "xdg_wm_base or wl_seat\n");
+    return false;
+  }
+
+  host->surface = wl_compositor_create_surface(host->compositor);
+  host->xdg_surface_obj =
+      xdg_wm_base_get_xdg_surface(host->wm_base, host->surface);
+  xdg_surface_add_listener(host->xdg_surface_obj, &kXdgSurfaceListener, host);
+  host->toplevel = xdg_surface_get_toplevel(host->xdg_surface_obj);
+  xdg_toplevel_add_listener(host->toplevel, &kToplevelListener, host);
+  xdg_toplevel_set_title(host->toplevel, "CEF embedded in a Wayland client");
+  xdg_toplevel_set_app_id(host->toplevel, "org.cef.cefembed_wayland");
+  // Tell the compositor as well, so the window cannot be dragged below what
+  // this program is willing to paint. OnToplevelConfigure() clamps regardless,
+  // since a compositor is free to ignore this.
+  xdg_toplevel_set_min_size(host->toplevel, kMinWidth, kMinHeight);
+
+  wl_surface_commit(host->surface);
+  while (!host->configured && wl_display_dispatch(host->display) != -1) {
+  }
+
+  return host->configured;
+}
+
+// Reads the default queue without stealing events from Chromium's queue. The
+// prepare_read/read_events pair is the only safe way to share a connection
+// between two dispatchers.
+//
+// The poll timeout matters: wl_display_read_events() blocks until something
+// arrives, so without it CefDoMessageLoopWork() would only run when the
+// compositor happened to send us an event. CEF is configured with
+// external_message_pump and needs to be serviced on its own schedule.
+void PumpWayland(Host* host, int timeout_ms) {
+  while (wl_display_prepare_read(host->display) != 0) {
+    wl_display_dispatch_pending(host->display);
+  }
+  wl_display_flush(host->display);
+
+  pollfd pfd = {wl_display_get_fd(host->display), POLLIN, 0};
+  if (poll(&pfd, 1, timeout_ms) > 0 && (pfd.revents & POLLIN)) {
+    wl_display_read_events(host->display);
+  } else {
+    wl_display_cancel_read(host->display);
+  }
+  wl_display_dispatch_pending(host->display);
+
+  // A protocol error kills the connection silently otherwise: libwayland stops
+  // sending and every later request is dropped, which looks like a freeze.
+  if (const int err = wl_display_get_error(host->display)) {
+    uint32_t id = 0;
+    const wl_interface* interface = nullptr;
+    const uint32_t code =
+        wl_display_get_protocol_error(host->display, &interface, &id);
+    fprintf(stderr,
+            "cefembed: wayland connection failed: errno=%d protocol_error=%u "
+            "interface=%s id=%u\n",
+            err, code, interface ? interface->name : "(none)", id);
+    host->closed = true;
+  }
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  // Select the Wayland backend explicitly. Ozone otherwise picks X11 wherever
+  // DISPLAY is set, and the wl_surface this program puts in parent_window would
+  // then be read as an X11 Window -- undefined behaviour that CEF has no way to
+  // diagnose. The switch has to be on the command line rather than in
+  // CefSettings because subprocesses inherit argv, and it is added only when
+  // the caller did not pick a platform, so that the failing case stays testable
+  // with an explicit --ozone-platform=x11.
+  std::vector<char*> args(argv, argv + argc);
+  static char kOzoneWayland[] = "--ozone-platform=wayland";
+  const bool has_platform_switch =
+      std::any_of(args.begin(), args.end(), [](const char* arg) {
+        return std::string_view(arg).starts_with("--ozone-platform");
+      });
+  if (!has_platform_switch) {
+    args.push_back(kOzoneWayland);
+  }
+  argc = static_cast<int>(args.size());
+  argv = args.data();
+
+  CefMainArgs main_args(argc, argv);
+
+  const int exit_code = CefExecuteProcess(main_args, nullptr, nullptr);
+  if (exit_code >= 0) {
+    return exit_code;
+  }
+
+  Host host;
+  g_host = &host;
+  if (!CreateHostWindow(&host)) {
+    return 1;
+  }
+
+  // Must happen before CefInitialize: Chromium connects to the compositor while
+  // initializing Ozone, and a wl_surface cannot be shared across connections.
+  cef_set_wayland_display(host.display);
+
+  CefSettings settings;
+  settings.no_sandbox = true;
+  settings.external_message_pump = true;
+  CefString(&settings.root_cache_path).FromASCII("/tmp/cefembed_wayland");
+
+  if (!CefInitialize(main_args, settings, nullptr, nullptr)) {
+    fprintf(stderr, "cefembed: CefInitialize failed\n");
+    return 1;
+  }
+
+  std::string url = "https://store.steampowered.com/";
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg(argv[i]);
+    if (arg.rfind("--url=", 0) == 0) {
+      url = arg.substr(6);
+    }
+  }
+
+  CefWindowInfo window_info;
+  window_info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;
+  // parent_window carries the wl_surface here, the same field an X11 embedder
+  // fills with an X11 Window. The xdg_surface is what popups anchor on.
+  window_info.SetAsChild(reinterpret_cast<CefWindowHandle>(host.surface),
+                         host.xdg_surface_obj, ContentBounds(&host));
+
+  CefBrowserSettings browser_settings;
+  CefRefPtr<EmbedClient> client(new EmbedClient());
+  if (!CefBrowserHost::CreateBrowser(window_info, client, url, browser_settings,
+                                     nullptr, nullptr)) {
+    fprintf(stderr, "cefembed: CreateBrowser failed; see the log above\n");
+    CefShutdown();
+    return 1;
+  }
+
+  while (!host.closed) {
+    CefDoMessageLoopWork();
+    PumpWayland(&host, /*timeout_ms=*/8);
+  }
+  printf("cefembed: leaving the event loop\n");
+  fflush(stdout);
+
+  // CreateBrowser() is asynchronous: |browser| only appears in
+  // OnAfterCreated(). Closing the window before that callback arrives -- easy
+  // to do, since the page takes a moment to load -- would otherwise fall past
+  // the CloseBrowser() below and shut CEF down with a browser still being
+  // built, which is the same teardown-under-a-live-browser crash the rest of
+  // this path exists to avoid. Wait for creation to land first.
+  for (int i = 0; i < 400 && !g_host->browser; ++i) {
+    CefDoMessageLoopWork();
+    PumpWayland(&host, /*timeout_ms=*/5);
+  }
+
+  if (!g_host->browser) {
+    fprintf(stderr,
+            "cefembed: the browser never finished being created; leaving "
+            "without CefShutdown() rather than shutting down over a pending "
+            "creation\n");
+    return 2;
+  }
+
+  {
+    g_host->browser->GetHost()->CloseBrowser(true);
+    // Both loops have to keep running here. CEF tears the browser window down
+    // through Wayland requests and replies, so pumping only
+    // CefDoMessageLoopWork leaves the window half-alive; CefShutdown then
+    // destroys WaylandConnection underneath it, and ~WaylandPointer dispatches
+    // a final pointer-leave into a window whose WaylandWindowManager is already
+    // gone.
+    for (int i = 0; i < 400 && g_host->browser; ++i) {
+      CefDoMessageLoopWork();
+      PumpWayland(&host, /*timeout_ms=*/5);
+    }
+    if (g_host->browser) {
+      // Going into CefShutdown() anyway would destroy WaylandConnection under
+      // a live browser, which is a crash rather than a diagnostic. Leaving the
+      // process without shutting CEF down is the lesser evil, and the exit
+      // code makes the failure visible to whatever ran this.
+      fprintf(stderr,
+              "cefembed: browser did not close in time; leaving without "
+              "CefShutdown() rather than tearing the connection down "
+              "underneath it\n");
+      return 2;
+    }
+  }
+
+  // Only now: unmapping earlier stops the subsurface receiving frames, and the
+  // browser's teardown never finishes. Attaching a null buffer takes the window
+  // off screen without destroying anything, so the rest of CefShutdown() -- the
+  // slow part -- happens with nothing left to look at.
+  wl_surface_attach(host.surface, nullptr, 0, 0);
+  wl_surface_commit(host.surface);
+  wl_display_flush(host.display);
+
+  CefShutdown();
+
+  // After the null attach above the compositor is reading none of them, so
+  // this is the one point where every buffer can go regardless of |busy|.
+  for (const auto& buffer : host.buffers) {
+    DestroyBuffer(buffer.get());
+  }
+  host.buffers.clear();
+
+  // The compositor would reclaim all of this when the connection drops, but a
+  // sample that leaks its own protocol objects is a poor thing to copy from.
+  if (host.cursor_shape_device) {
+    wp_cursor_shape_device_v1_destroy(host.cursor_shape_device);
+  }
+  if (host.cursor_shape_manager) {
+    wp_cursor_shape_manager_v1_destroy(host.cursor_shape_manager);
+  }
+  if (host.pointer) {
+    wl_pointer_release(host.pointer);
+  }
+  if (host.seat) {
+    wl_seat_release(host.seat);
+  }
+  if (host.toplevel) {
+    xdg_toplevel_destroy(host.toplevel);
+  }
+  if (host.xdg_surface_obj) {
+    xdg_surface_destroy(host.xdg_surface_obj);
+  }
+  if (host.surface) {
+    wl_surface_destroy(host.surface);
+  }
+  if (host.wm_base) {
+    xdg_wm_base_destroy(host.wm_base);
+  }
+  if (host.shm) {
+    wl_shm_destroy(host.shm);
+  }
+  if (host.compositor) {
+    wl_compositor_destroy(host.compositor);
+  }
+  if (host.registry) {
+    wl_registry_destroy(host.registry);
+  }
+  if (host.display) {
+    wl_display_disconnect(host.display);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Adds the native windowed mode on Ozone/Wayland: a browser hosted inside a window the client application owns, the way `CefWindowInfo::SetAsChild` already works on X11. This is issue #2804.

Before deciding whether to read the rest: this needs a decision from you before it can be finished, and it is the first item in the dependency list in that issue. The API question is the blocker, not the code.

Some context first: I posted a demo and the branch in the issue before opening this (https://github.com/chromiumembedded/cef/issues/2804#issuecomment-5172235803), so this is not arriving cold. But the approach itself was not discussed there before the work started, which CONTRIBUTING asks for on architectural changes, and that was a mistake on my part. The branch exists as something concrete to react to, not as a decision already made. If the API shape below is wrong, it changes.

## Demonstration

https://github.com/user-attachments/assets/922224a9-f763-47cf-9713-baa3882475db

## What is here

Five commits. The first is a Chromium patch; the rest are CEF.

| | |
|---|---|
| `chromium: Add Wayland subsurface embedding to Ozone` | `patch/patches/ozone_wayland_embed_2804.patch` |
| `linux: Add Wayland API and runtime platform selection` | public API, `cef_ozone::IsWayland()` |
| `linux: Create windowed browsers on Wayland` | `browser_platform_delegate_native_linux.cc` |
| `linux: Add a Wayland embedding sample` | `tests/cefembed_wayland` |
| `docs: Add design notes for Wayland embedding` | `docs/wayland_embedding.md` |

The design and the reasoning behind each decision are in `docs/wayland_embedding.md`. This description covers what you need to decide and what you should not trust.

## The API decision

`cef_window_info_t::parent_window` carries the client's `wl_surface`. No new field: that member has always been an opaque native parent handle whose meaning depends on the platform (an `HWND` on Windows, an `NSView*` on macOS), and the `unsigned long` spelling on Linux is an artifact of X11 that holds a pointer on LP64. Existing embedders keep compiling and keep working.

The cost is the failure mode. A valid XID such as `0x2600004` is numerically indistinguishable from an address, so passing the wrong handle for the active platform is undefined rather than diagnosed. In practice the handle comes from the client's toolkit, which knows which platform it is on. If you would rather have a separate field and a diagnosable error, that is a reasonable call and this branch should change.

One member is appended, under `CEF_API_ADDED(CEF_EXPERIMENTAL)`:

```c
cef_xdg_surface_handle_t parent_xdg_surface;  // in, for popups
```

with a three-argument `SetAsChild(parent, parent_xdg, bounds)` alongside the existing form. May be null; popups then fall back to a degraded subsurface form, described in the docs.

An earlier revision also returned the browser's own `wl_surface` as an output member. It was removed, because a `wl_surface` is scoped to the connection the embedder already owns, so it told the embedder nothing it could act on.

The connection is passed process-wide, not per browser, because Chromium builds its `WaylandConnection` while initializing Ozone, inside `CefInitialize` and long before any `CefWindowInfo` exists:

```c
CEF_EXPORT void cef_set_wayland_display(cef_wayland_display_handle_t display);
```

The 2020 Igalia prototype put this on `CefWindowInfo`; that cannot work for the reason above.

`CefBrowserHost::SetWindowBounds()` is new and unavoidable: a `wl_subsurface` receives no configure events, so the client is the only source of layout. It is declared last in the class on purpose, because the translator moves versioned members to the end of the generated struct in declaration order, and putting it earlier would shift the existing experimental `set_ax_viewport_collapse`.

## The Chromium patch

This is what makes it not a small pull request. `patch/patches/ozone_wayland_embed_2804.patch` is the largest patch in the tree and the first to add files rather than only edit them. It shares the embedder's `wl_display`, because a `wl_surface` is scoped to one connection and `wl_subcompositor_get_subsurface()` rejects surfaces from another, and it adds a `WaylandWindow` subclass attached as a `wl_subsurface` of a bare surface with no `WaylandWindow` behind it. The rest is in the docs.

One thing from it belongs here rather than in the docs, because it is a bug and not a design decision. `RootWindowFromWlSurface()` used to read any `wl_surface`'s user data and cast it to `ui::WaylandSurface`, which on a shared connection is a pointer owned by the client's toolkit. Reproduced as a GPF by moving the mouse over a client's CSD borders. The patch splits the lookup by class so that only Chromium's own surfaces resolve.

Whether the patch belongs in CEF or upstream in Chromium is your call; I have no standing to make it. I understand what carrying it costs: it has to be rebased at every milestone, and it touches files that churn. I am willing to keep it rebased for as long as it is useful. Some of it may not need to be carried at all: the surface lookup fix above is independent of embedding and could be proposed to Chromium on its own.

What it does:

- `WaylandConnection` adopts an externally owned `wl_display`. A `wl_surface` is scoped to one connection and `wl_subcompositor_get_subsurface()` rejects surfaces from another, so there is no way to parent into the client's surface without sharing the connection. Smaller than expected, since Chromium already routes its traffic through a dedicated `wl_event_queue`.
- `WaylandEmbeddedWindow`, a `WaylandWindow` attached as a `wl_subsurface` of a bare `wl_surface` with no `WaylandWindow` behind it. Registered in `WaylandWindowManager` like any other, which is what makes accelerated-widget lookup resolve.
- Input split by class. `RootWindowFromWlSurface()` resolves only Chromium's own surfaces; only the keyboard and text input cross over from the embedder's, through a separate lookup. This also closes a latent memory-safety bug: that function used to read any `wl_surface`'s user data and cast it to `ui::WaylandSurface`, which on a shared connection is a pointer owned by the client's toolkit. Reproduced as a GPF by moving the mouse over a client's CSD borders.
- Activation derived from the seat and notified through the window manager, exactly as `WaylandToplevelWindow` does it.

The design tries hard to have no special cases. Where it diverges from the toplevel, the comment says why.

## Verified

Fedora 44, GNOME 50 Wayland, two monitors at different scales, against a local build of this branch.

Rendering inside the client's window, pointer, keyboard, `<select>` and context menus, resize, close. IME with ibus and Intelligent Pinyin: preedit underlined in the field, candidate window next to the caret, commit landing in the input. Drag and drop in both directions, including drops over the client's own chrome still going to the client. HiDPI with fractional scaling, starting on either kind of output and dragging between them. Several browsers in one window, created, moved, hidden and closed independently, with keyboard focus following both `SetFocus()` and a click.

The X11 path is unchanged behaviour with the same binary.

Most of that was exercised with a separate host application rather than the sample in this branch:

https://github.com/leandromqrs/cef-wayland-embed-sample

It is an interactive suite in Rust over `winit` that creates and destroys browsers at runtime in all three CEF hosting modes, moves and resizes panels independently, and reports what the host saw next to what the browser saw. It also runs against stock CEF, which is what makes the comparison meaningful. The C++ `tests/cefembed_wayland` in this branch is the minimal reference; that one is the test rig.

34 unit tests across both layers: 30 in Ozone on the `WaylandTest` harness, 4 for the `cef_window_info_t` ABI. The 476 Wayland tests in the tree still pass with the patch applied. Each new test was verified by reintroducing the defect it covers.

## Not verified

**The macOS build.** No machine available. Audited instead: of the 18 files this branch touches, 12 are either not compiled at all or excluded by `if (is_linux)` and `#if defined(OS_LINUX)`. The six that remain hold exactly one platform-guarded symbol, `SetHostBounds`, guarded identically in its declaration, its definition and its call site, and `SetWindowBounds`, which is pure virtual in `cef_browser.h` but has a single implementation in a cross-platform file. The residual risk is a compile error, not a runtime defect. It is not zero, though, and your CI will find it faster than I can.

## Known limitations

Two, both with their causes and the reasoning in the docs. Resizing lags the client by a frame, because `wl_subsurface.set_position` is double-buffered on the parent surface and the two surfaces are submitted in separate compositor frames; `WaylandBubble` carries the same TODO upstream (https://crbug.com/329145822). And where the client exposes no `xdg_surface`, popups fall back to a `wl_subsurface`, which cannot extend past the client's window or hold a grab, so a dropdown near an edge is clipped and clicking outside does not dismiss it. Failing instead is not available, because `WaylandWindow::Create()` returning null makes views destroy the widget inside `Widget::Show()`, which `CHECK`s. Both CEF and Ozone log a warning naming the limitation when the fallback is taken.

## On how this was written

Written with heavy AI assistance, disclosed in the commit trailers. I take responsibility for all of it: I can explain any decision here, and the reasoning behind each is either in `docs/wayland_embedding.md` or in the comment next to the code.